### PR TITLE
Change IDs into enumerations

### DIFF
--- a/templates/archetypes.rs.jinja2
+++ b/templates/archetypes.rs.jinja2
@@ -69,13 +69,15 @@ pub enum ArchetypeId {
     {%- endfor %}
 }
 
-#[allow(dead_code)]
 impl ArchetypeId {
     {%- for archetype in ecs.archetypes %}
     /// A [`NonZeroU64`](core::num::NonZeroU64) representation of [`ArchetypeId::{{ archetype.name.raw }}`](ArchetypeId::{{ archetype.name.raw }}) archetype.
     pub const {{ archetype.name.field | upper }}_ID_VALUE: core::num::NonZeroU64 = core::num::NonZeroU64::new({{ archetype.id }}).expect("Error at ECS construction time");
     {%- endfor %}
+}
 
+#[allow(dead_code)]
+impl ArchetypeId {
     /// Returns this ID as a [`NonZeroU64`](core::num::NonZeroU64) value.
     pub const fn as_nonzero_u64(&self) -> core::num::NonZeroU64 {
         match self {

--- a/templates/archetypes.rs.jinja2
+++ b/templates/archetypes.rs.jinja2
@@ -72,14 +72,15 @@ pub enum ArchetypeId {
 #[allow(dead_code)]
 impl ArchetypeId {
     {%- for archetype in ecs.archetypes %}
-    pub const {{ archetype.name.raw | upper }}_ID: core::num::NonZeroU64 = core::num::NonZeroU64::new({{ archetype.id }}).expect("Error at ECS construction time");
+    /// A [`NonZeroU64`](core::num::NonZeroU64) representation of [`ArchetypeId::{{ archetype.name.raw }}`](ArchetypeId::{{ archetype.name.raw }}) archetype.
+    pub const {{ archetype.name.field | upper }}_ID_VALUE: core::num::NonZeroU64 = core::num::NonZeroU64::new({{ archetype.id }}).expect("Error at ECS construction time");
     {%- endfor %}
 
     /// Returns this ID as a [`NonZeroU64`](core::num::NonZeroU64) value.
     pub const fn as_nonzero_u64(&self) -> core::num::NonZeroU64 {
         match self {
             {%- for archetype in ecs.archetypes %}
-            Self::{{ archetype.name.raw }} => Self::{{ archetype.name.raw | upper }}_ID,
+            Self::{{ archetype.name.raw }} => Self::{{ archetype.name.field | upper }}_ID_VALUE,
             {%- endfor %}
         }
     }
@@ -440,9 +441,9 @@ impl core::ops::DerefMut for {{ archetype.name.raw }}Entity {
 #[allow(dead_code)]
 impl {{ archetype.name.type }} {
     /// The IDs of the components used by this archetype, in ascending order.
-    pub const COMPONENT_IDS: [ComponentId; {{ archetype.component_count }}] = [
+    pub const COMPONENTS: [ComponentId; {{ archetype.component_count }}] = [
         {%- for id in archetype.component_ids %}
-        ComponentId::new({{- id -}}).expect("Invalid ID on ECS construction time"),
+        ComponentId::COMPONENT_{{- id -}},
         {%- endfor %}
     ];
 

--- a/templates/components.rs.jinja2
+++ b/templates/components.rs.jinja2
@@ -1,31 +1,55 @@
 /// The ID of a [`Component`].
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
-pub struct ComponentId(core::num::NonZeroU64);
+#[repr(u32)]
+pub enum ComponentId {
+    {%- for component in ecs.components %}
+    {%- if component.description %}
+    /// {{ component.description }}
+    ///
+    /// For details, see the [`{{ component.name.type }}`]({{ component.name.type }}) Struct.
+    {%- else %}
+    /// The [`{{ component.name.raw }}`]({{ component.name.type }}) component.
+    {%- endif %}
+    {{ component.name.raw }} = {{ component.id }},
+    {%- endfor %}
+}
 
 #[allow(dead_code)]
 impl ComponentId {
-    pub const fn new(id: u64) -> Option<Self> {
-        if let Some(id) = core::num::NonZeroU64::new(id) {
-            Some(Self(id))
-        } else {
-            None
-        }
-    }
+    {%- for component in ecs.components %}
+    /// A [`NonZeroU64`](core::num::NonZeroU64) representation of [`ComponentId::{{ component.name.raw }}`](ComponentId::{{ component.name.raw }}) component.
+    pub const {{ component.name.field | upper }}_ID_VALUE: core::num::NonZeroU64 = core::num::NonZeroU64::new({{ component.id }}).expect("Error at ECS construction time");
+    {%- endfor %}
+}
 
+#[allow(dead_code)]
+impl ComponentId {
+    {%- for component in ecs.components %}
+    /// Compile-time constant lookup of [`ComponentId::{{ component.name.raw }}`](ComponentId::{{ component.name.raw }}).
+    const COMPONENT_{{ component.id }}: ComponentId = ComponentId::{{ component.name.raw }};
+    {%- endfor %}
+}
+
+#[allow(dead_code)]
+impl ComponentId {
     /// Returns this ID as a [`NonZeroU64`](core::num::NonZeroU64) value.
     pub const fn as_nonzero_u64(&self) -> core::num::NonZeroU64 {
-        self.0
+        match self {
+            {%- for component in ecs.components %}
+            Self::{{ component.name.raw }} => Self::{{ component.name.field | upper }}_ID_VALUE,
+            {%- endfor %}
+        }
     }
 
     /// Returns this ID as a `u64` value.
     pub const fn as_u64(&self) -> u64 {
-            self.0.get()
+        self.as_nonzero_u64().get()
     }
 }
 
 impl core::hash::Hash for ComponentId {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state);
+        self.as_u64().hash(state);
     }
 }
 
@@ -80,7 +104,7 @@ impl {{ component.name.type }} {
 
 #[automatically_derived]
 impl Component for {{ component.name.type }} {
-    const ID: ComponentId = ComponentId(core::num::NonZeroU64::new({{ component.id }}).expect("A zero component ID was provided"));
+    const ID: ComponentId = ComponentId::{{ component.name.raw }};
 }
 
 impl PartialEq<ComponentId> for {{ component.name.type }} {

--- a/templates/components.rs.jinja2
+++ b/templates/components.rs.jinja2
@@ -10,6 +10,20 @@ pub enum ComponentId {
     {%- else %}
     /// The [`{{ component.name.raw }}`]({{ component.name.type }}) component.
     {%- endif %}
+    {%- if component.affected_archetype_count > 0 %}
+    ///
+    /// # Archetype Use
+    /// This component is used by the following archetypes:
+    /// {% for archetype in component.affected_archetypes %}
+    /// - [`{{archetype.type}}`] ([`ArchetypeId::{{archetype.raw}}`]){%- endfor %}
+    {%- endif %}
+    {%- if component.affected_archetype_count > 0 %}
+    ///
+    /// # System Use
+    /// This component is used by the following systems:
+    /// {% for system in component.affected_systems %}
+    /// - [`{{system.type}}`] ([`SystemId::{{system.raw}}`]){%- endfor %}
+    {%- endif %}
     {{ component.name.raw }} = {{ component.id }},
     {%- endfor %}
 }
@@ -82,10 +96,24 @@ pub trait Component: 'static + Send + Sync {
 {% if component.description %}
 /// {{ component.description }}
 {%- else %}
-/// A component.
+/// A `{{ component.name.raw }}` component.
 {%- endif %}
 ///
 /// See also [`{{ component.name.raw }}Data`] for the actual data.
+{%- if component.affected_archetype_count > 0 %}
+///
+/// # Archetype Use
+/// This component is used by the following archetypes:
+/// {% for archetype in component.affected_archetypes %}
+/// - [`{{archetype.type}}`] ([`ArchetypeId::{{archetype.raw}}`]){%- endfor %}
+{%- endif %}
+{%- if component.affected_archetype_count > 0 %}
+///
+/// # System Use
+/// This component is used by the following systems:
+/// {% for system in component.affected_systems %}
+/// - [`{{system.type}}`] ([`SystemId::{{system.raw}}`]){%- endfor %}
+{%- endif %}
 #[derive(Debug, Clone)]
 pub struct {{ component.name.type }}({{ component.name.raw }}Data);
 

--- a/templates/components.rs.jinja2
+++ b/templates/components.rs.jinja2
@@ -79,6 +79,16 @@ impl From<ComponentId> for u64 {
     }
 }
 
+impl core::fmt::Display for ComponentId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        match self {
+            {%- for component in ecs.components %}
+            Self::{{ component.name.raw }} => write!(f, "{{ component.name.raw }} (ID {{ component.id }})"),
+            {%- endfor %}
+        }
+    }
+}
+
 /// Marker trait for components.
 pub trait Component: 'static + Send + Sync {
     /// The ID of this component.

--- a/templates/systems.rs.jinja2
+++ b/templates/systems.rs.jinja2
@@ -10,6 +10,25 @@ pub enum SystemId {
     {%- else %}
     /// The [`{{ system.name.raw }}`]({{ system.name.type }}) system.
     {%- endif %}
+    {%- if (system.inputs | length > 0) %}
+    ///
+    /// ### Reads
+    /// {% for input in system.inputs %}
+    /// - [`{{ input.type }}`]{% endfor %}
+    {%- endif %}
+    {%- if (system.outputs | length > 0) %}
+    ///
+    /// ### Mutates
+    /// {% for output in system.outputs %}
+    /// - [`{{ output.type }}`]{% endfor %}
+    {%- endif %}
+    {%- if system.affected_archetype_count > 0 %}
+    ///
+    /// # Archetype Use
+    /// This component processes components in the following archetypes:
+    /// {% for archetype in system.affected_archetypes %}
+    /// - [`{{archetype.type}}`] ([`ArchetypeId::{{archetype.raw}}`]){%- endfor %}
+    {%- endif %}
     {{ system.name.raw }} = {{ system.id }},
     {%- endfor %}
 }
@@ -266,14 +285,25 @@ pub trait System{{ phase.name.type }}Events {
 ///
 /// The business logic is implemented via the [`Apply{{ system.name.type }}`] trait.
 /// See also [`{{ system.name.raw }}Data`] for the systems-specific data.
+{%- if (system.inputs | length > 0) %}
 ///
 /// ### Reads
 /// {% for input in system.inputs %}
 /// - [`{{ input.type }}`]{% endfor %}
+{%- endif %}
+{%- if (system.outputs | length > 0) %}
 ///
 /// ### Mutates
 /// {% for output in system.outputs %}
 /// - [`{{ output.type }}`]{% endfor %}
+{%- endif %}
+{%- if system.affected_archetype_count > 0 %}
+///
+/// # Archetype Use
+/// This component processes components in the following archetypes:
+/// {% for archetype in system.affected_archetypes %}
+/// - [`{{archetype.type}}`] ([`ArchetypeId::{{archetype.raw}}`]){%- endfor %}
+{%- endif %}
 #[derive(Debug)]
 pub struct {{ system.name.type }}({{ system.name.type }}Data);
 

--- a/templates/systems.rs.jinja2
+++ b/templates/systems.rs.jinja2
@@ -1,22 +1,45 @@
 /// The ID of a [`System`].
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
-pub struct SystemId(core::num::NonZeroU64);
+#[repr(u32)]
+pub enum SystemId {
+    {%- for system in ecs.systems %}
+    {%- if system.description %}
+    /// {{ system.description }}
+    ///
+    /// For details, see the [`{{ system.name.type }}`]({{ system.name.type }}) Struct.
+    {%- else %}
+    /// The [`{{ system.name.raw }}`]({{ system.name.type }}) system.
+    {%- endif %}
+    {{ system.name.raw }} = {{ system.id }},
+    {%- endfor %}
+}
+
+impl SystemId {
+    {%- for system in ecs.systems %}
+    /// A [`NonZeroU64`](core::num::NonZeroU64) representation of [`SystemId::{{ system.name.raw }}`](SystemId::{{ system.name.raw }}) system.
+    pub const {{ system.name.field | upper }}_ID_VALUE: core::num::NonZeroU64 = core::num::NonZeroU64::new({{ system.id }}).expect("Error at ECS construction time");
+    {%- endfor %}
+}
 
 impl SystemId {
     /// Returns this ID as a [`NonZeroU64`](core::num::NonZeroU64) value.
     pub const fn as_nonzero_u64(&self) -> core::num::NonZeroU64 {
-        self.0
+        match self {
+            {%- for system in ecs.systems %}
+            Self::{{ system.name.raw }} => Self::{{ system.name.field | upper }}_ID_VALUE,
+            {%- endfor %}
+        }
     }
 
     /// Returns this ID as a `u64` value.
     pub const fn as_u64(&self) -> u64 {
-        self.0.get()
+        self.as_nonzero_u64().get()
     }
 }
 
 impl core::hash::Hash for SystemId {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state);
+        self.as_u64().hash(state);
     }
 }
 
@@ -29,6 +52,16 @@ impl From<SystemId> for core::num::NonZeroU64 {
 impl From<SystemId> for u64 {
     fn from(value: SystemId) -> u64 {
         value.as_u64()
+    }
+}
+
+impl core::fmt::Display for SystemId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        match self {
+            {%- for system in ecs.systems %}
+            Self::{{ system.name.raw }} => write!(f, "{{ system.name.raw }} (ID {{ system.id }})"),
+            {%- endfor %}
+        }
     }
 }
 
@@ -574,7 +607,7 @@ impl {{ system.name.type }} {
 
 #[automatically_derived]
 impl System for {{ system.name.type }} {
-    const ID: SystemId = SystemId(core::num::NonZeroU64::new({{ system.id }}).expect("A zero system ID was provided"));
+    const ID: SystemId = SystemId::{{ system.name.raw }};
 }
 
 impl PartialEq<SystemId> for {{ system.name.type }} {


### PR DESCRIPTION
This pull request includes changes to the `src` and `templates` directories to enhance the handling and documentation of components, systems, and archetypes in the ECS (Entity Component System) framework. The most important changes include the addition of new fields to the `Component` struct, the implementation of the `finish` method for `Component`, and the conversion of `ComponentId` and `SystemId` to enums with detailed documentation.

### Enhancements to `Component` struct and methods:

* [`src/component.rs`](diffhunk://#diff-c34cb87be68214956fa84ca439e1a52f71ace0cae10c5f8e5e15d072aace9ed8R17-R36): Added new fields to the `Component` struct to track affected archetypes and systems, and implemented the `finish` method to populate these fields. [[1]](diffhunk://#diff-c34cb87be68214956fa84ca439e1a52f71ace0cae10c5f8e5e15d072aace9ed8R17-R36) [[2]](diffhunk://#diff-c34cb87be68214956fa84ca439e1a52f71ace0cae10c5f8e5e15d072aace9ed8R72-R103)

### Updates to ECS initialization and error handling:

* [`src/ecs.rs`](diffhunk://#diff-75f9f0489447c8e2c0b997f7ae79df74a31029ad1306315af83ae2ef47d33f5cR46-R49): Modified the ECS initialization to call the `finish` method for each component, updated error handling for system dependencies and state definitions to improve readability. [[1]](diffhunk://#diff-75f9f0489447c8e2c0b997f7ae79df74a31029ad1306315af83ae2ef47d33f5cR46-R49) [[2]](diffhunk://#diff-75f9f0489447c8e2c0b997f7ae79df74a31029ad1306315af83ae2ef47d33f5cL94-R100) [[3]](diffhunk://#diff-75f9f0489447c8e2c0b997f7ae79df74a31029ad1306315af83ae2ef47d33f5cL134-R142) [[4]](diffhunk://#diff-75f9f0489447c8e2c0b997f7ae79df74a31029ad1306315af83ae2ef47d33f5cL245-R264)

### Conversion of `ComponentId` and `SystemId` to enums:

* [`templates/components.rs.jinja2`](diffhunk://#diff-429f1cccb33d43f3218c41b613bd8bff64480ef4fafd5abc3aed64fb9099ece8L3-R66): Converted `ComponentId` to an enum, added detailed documentation for each component, and updated related methods. [[1]](diffhunk://#diff-429f1cccb33d43f3218c41b613bd8bff64480ef4fafd5abc3aed64fb9099ece8L3-R66) [[2]](diffhunk://#diff-429f1cccb33d43f3218c41b613bd8bff64480ef4fafd5abc3aed64fb9099ece8R82-R91) [[3]](diffhunk://#diff-429f1cccb33d43f3218c41b613bd8bff64480ef4fafd5abc3aed64fb9099ece8L61-R126) [[4]](diffhunk://#diff-429f1cccb33d43f3218c41b613bd8bff64480ef4fafd5abc3aed64fb9099ece8L83-R145)
* [`templates/systems.rs.jinja2`](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfL3-R61): Converted `SystemId` to an enum, added detailed documentation for each system, and updated related methods. [[1]](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfL3-R61) [[2]](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfR77-R86) [[3]](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfR288-R306) [[4]](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfL577-R640)

### Improvements to archetype and component ID handling:

* [`templates/archetypes.rs.jinja2`](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828L72-R85): Updated the `ArchetypeId` implementation to provide a `NonZeroU64` representation and improved the documentation. [[1]](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828L72-R85) [[2]](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828L443-R448)