### PR TITLE
Implement individual component access by entity ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ fn register_example_shader<E, Q>(world: &MainWorld<E, Q>) -> WgpuShaderEntityRef
     });
 
     // Get it back
-    self.get_wgpu_shader(entity_id).unwrap()
+    self.get_wgpu_shader_entity(entity_id).unwrap()
 }
 ```
 

--- a/templates/archetypes.rs.jinja2
+++ b/templates/archetypes.rs.jinja2
@@ -345,16 +345,63 @@ impl {{ archetype.name.type }} {
     pub fn iter(&self) -> {{ archetype.name.raw }}EntityIterator {
         {{ archetype.name.raw }}EntityIterator::new(self)
     }
+    {%- for component in archetype.components %}
 
-    /// Gets the entity at the specified index.
+    /// Gets the `{{component.raw}}` component at the specified index.
     #[allow(dead_code)]
-    pub fn get_at(&self, index: usize) -> Option<{{ archetype.name.raw }}EntityRef> {
+    #[inline]
+    pub fn get_{{component.field}}_component_at(&self, index: usize) -> Option<&{{component.type}}> {
         if index > self.len() {
             return None;
         }
 
         {%- if ecs.allow_unsafe %}
-        Some(unsafe { self.get_at_unchecked(index) })
+        Some(unsafe { self.get_{{component.field}}_component_at_unchecked(index) })
+        {%- else %}
+        Some(&self.{{ component_name.fields }}[index])
+        {%- endif %}
+    }
+
+    /// Mutably gets the `{{component.raw}}` component at the specified index.
+    #[allow(dead_code)]
+    #[inline]
+    pub fn get_{{component.field}}_component_at_mut(&mut self, index: usize) -> Option<&mut {{component.type}}> {
+        if index > self.len() {
+            return None;
+        }
+
+        {%- if ecs.allow_unsafe %}
+        Some(unsafe { self.get_{{component.field}}_component_at_unchecked_mut(index) })
+        {%- else %}
+        Some(&mut self.{{ component_name.fields }}[index])
+        {%- endif %}
+    }
+
+    /// Gets the `{{component.raw}}` component at the specified index.
+    #[allow(dead_code)]
+    #[inline]
+    pub unsafe fn get_{{component.field}}_component_at_unchecked(&self, index: usize) -> &{{component.type}} {
+        self.{{ component.fields }}.get_unchecked(index)
+    }
+
+    /// Gets the `{{component.raw}}` component at the specified index.
+    #[allow(dead_code)]
+    #[inline]
+    pub unsafe fn get_{{component.field}}_component_at_unchecked_mut(&mut self, index: usize) -> &mut {{component.type}} {
+        self.{{ component.fields }}.get_unchecked_mut(index)
+    }
+
+    {%- endfor %}
+
+    /// Gets the entity at the specified index.
+    #[allow(dead_code)]
+    pub fn get_entity_at(&self, index: usize) -> Option<{{ archetype.name.raw }}EntityRef> {
+        if index > self.len() {
+            return None;
+        }
+
+        {%- if ecs.allow_unsafe %}
+        Some(unsafe { self.get_entity_at_unchecked(index) })
         {%- else %}
         Some({{ archetype.name.raw }}EntityRef {
             entity_id: self.entities[index],
@@ -367,13 +414,13 @@ impl {{ archetype.name.type }} {
 
     /// Mutably gets the entity at the specified index.
     #[allow(dead_code)]
-    pub fn get_at_mut(&mut self, index: usize) -> Option<{{ archetype.name.raw }}EntityMut> {
+    pub fn get_entity_at_mut(&mut self, index: usize) -> Option<{{ archetype.name.raw }}EntityMut> {
         if index > self.len() {
             return None;
         }
 
         {%- if ecs.allow_unsafe %}
-        Some(unsafe { self.get_at_unchecked_mut(index) })
+        Some(unsafe { self.get_entity_at_unchecked_mut(index) })
         {%- else %}
         Some({{ archetype.name.raw }}EntityMut {
             entity_id: self.entities[index],
@@ -386,7 +433,7 @@ impl {{ archetype.name.type }} {
 
     /// Gets the entity at the specified index.
     #[allow(dead_code)]
-    pub unsafe fn get_at_unchecked(&self, index: usize) -> {{ archetype.name.raw }}EntityRef {
+    pub unsafe fn get_entity_at_unchecked(&self, index: usize) -> {{ archetype.name.raw }}EntityRef {
         {{ archetype.name.raw }}EntityRef {
             entity_id: *self.entities.get_unchecked(index),
             {%- for component_name in archetype.components %}
@@ -397,7 +444,7 @@ impl {{ archetype.name.type }} {
 
     /// Gets the entity at the specified index.
     #[allow(dead_code)]
-    pub unsafe fn get_at_unchecked_mut(&mut self, index: usize) -> {{ archetype.name.raw }}EntityMut {
+    pub unsafe fn get_entity_at_unchecked_mut(&mut self, index: usize) -> {{ archetype.name.raw }}EntityMut {
         {{ archetype.name.raw }}EntityMut {
             entity_id: *self.entities.get_unchecked(index),
             {%- for component_name in archetype.components %}
@@ -816,14 +863,14 @@ impl GetEntityRef for {{ archetype.name.type }} {
     #[inline(always)]
     #[allow(clippy::needless_lifetimes, dead_code)]
     fn get_at<'archetype>(&'archetype self, index: usize) -> Option<Self::EntityRef<'archetype>> {
-        self.get_at(index)
+        self.get_entity_at(index)
     }
 
     /// See [`{{ archetype.name.type }}::get_at_unchecked`]({{ archetype.name.type }}::get_at_unchecked).
     #[inline(always)]
     #[allow(clippy::needless_lifetimes, dead_code)]
     unsafe fn get_at_unchecked<'archetype>(&'archetype self, index: usize) -> Self::EntityRef<'archetype> {
-        unsafe { self.get_at_unchecked(index) }
+        unsafe { self.get_entity_at_unchecked(index) }
     }
 }
 {%- endfor %}

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -429,7 +429,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         self
             .archetypes
             .{{ archetype.name.field }}
-            .get_at(ear.index)
+            .get_entity_at(ear.index)
     }
 
     /// Mutably accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
@@ -444,7 +444,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         self
             .archetypes
             .{{ archetype.name.field }}
-            .get_at_mut(ear.index)
+            .get_entity_at_mut(ear.index)
     }
 
     /// Spawn a new `{{ archetype.name.raw }}` entity into the world given its [`{{ archetype.name.raw }}EntityData`].

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -415,6 +415,37 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     }
     {%- endif %}
     {%- endfor %}
+    {%- for component, archetypes in world.components|items %}
+
+    /// Gets the `{{component.raw}}` component of the specified entity.
+    #[allow(dead_code)]
+    #[inline]
+    pub fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}> {
+        let ear = self.entity_locations.get(&entity_id)?;
+        match ear.archetype {
+            {%- for archetype in archetypes %}
+            {{ archetype.type }}::ID => self.archetypes.{{ archetype.field }}.get_{{component.field}}_component_at(ear.index),
+            {%- endfor %}
+            #[allow(dead_code)]
+            _ => None
+        }
+    }
+
+    /// Mutably gets the `{{component.raw}}` component of the specified entity.
+    #[allow(dead_code)]
+    #[inline]
+    pub fn get_{{component.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.type}}> {
+        let ear = self.entity_locations.get(&entity_id)?;
+        match ear.archetype {
+            {%- for archetype in archetypes %}
+            {{ archetype.type }}::ID => self.archetypes.{{ archetype.field }}.get_{{component.field}}_component_at_mut(ear.index),
+            {%- endfor %}
+            #[allow(dead_code)]
+            _ => None
+        }
+    }
+
+    {%- endfor %}
     {%- for archetype in world.archetypes %}
 
     /// Accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -1215,3 +1215,57 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
 {%- endfor %}
 }
 {%- endfor %}
+
+pub trait ComponentAccess {
+    {%- for component in ecs.components %}
+
+    /// Gets the [`{{component.name.raw}}`]({{component.name.type}}) component of the specified entity.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{component.name.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.name.type}}> {
+        None
+    }
+    {%- endfor %}
+}
+
+pub trait ComponentAccessMut: ComponentAccess {
+    {%- for component in ecs.components %}
+
+    /// Mutably gets the [`{{component.name.raw}}`]({{component.name.type}}) component of the specified entity.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{component.name.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.name.type}}> {
+        None
+    }
+    {%- endfor %}
+}
+{%- for world in ecs.worlds %}
+
+//noinspection RsSortImplTraitMembers
+impl<E, Q> ComponentAccess for {{ world.name.type }}<E, Q> {
+    {%- for component in world.components %}
+
+    /// Gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}> {
+        self.get_{{component.field}}_component(entity_id)
+    }
+    {%- endfor %}
+}
+{%- endfor %}
+{%- for world in ecs.worlds %}
+
+//noinspection RsSortImplTraitMembers
+impl<E, Q> ComponentAccessMut for {{ world.name.type }}<E, Q> {
+    {%- for component in world.components %}
+
+    /// Mutably gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{component.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.type}}> {
+        self.get_{{component.field}}_component_mut(entity_id)
+    }
+    {%- endfor %}
+}
+{%- endfor %}

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -418,7 +418,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     {%- for archetype in world.archetypes %}
 
     /// Accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
-    pub fn get_{{ archetype.name.field }}(
+    pub fn get_{{ archetype.name.field }}_entity(
         &self,
         entity_id: EntityId
     ) -> Option<{{ archetype.name.raw }}EntityRef> {
@@ -433,7 +433,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     }
 
     /// Mutably accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
-    pub fn get_{{ archetype.name.field }}_mut(
+    pub fn get_{{ archetype.name.field }}_entity_mut(
         &mut self,
         entity_id: EntityId
     ) -> Option<{{ archetype.name.raw }}EntityMut> {


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of components and entities in the ECS (Entity Component System) framework. The changes include renaming methods for clarity, adding new methods for component access, and updating templates to reflect these changes.

Relates to:

- https://github.com/sunsided/sillyecs/issues/4

### Method Renaming for Clarity:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L299-R299): Renamed `get_wgpu_shader` to `get_wgpu_shader_entity` for better clarity.
* [`templates/archetypes.rs.jinja2`](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828R348-R404): Renamed various `get_at` methods to `get_entity_at` to make their purpose clearer. [[1]](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828R348-R404) [[2]](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828L370-R423) [[3]](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828L389-R436) [[4]](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828L400-R447) [[5]](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828L819-R873)
* [`templates/world.rs.jinja2`](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbR417-R452): Renamed `get_<archetype>` methods to `get_<archetype>_entity` for consistency. [[1]](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbR417-R452) [[2]](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbL432-R467) [[3]](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbL447-R478)

### Component Handling Enhancements:

* [`src/world.rs`](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R35-R37): Added a new `components` field to the `World` struct to keep track of components used in the world.
* [`src/world.rs`](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R50-R64): Modified the `World` implementation to populate the `components` field based on the world's archetypes.

### Component Access Methods:

* [`templates/archetypes.rs.jinja2`](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828R348-R404): Added methods for getting components at specific indices, both safely and unsafely.
* [`templates/world.rs.jinja2`](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbR1218-R1271): Added methods for accessing components of specified entities.

These changes enhance the clarity and functionality of the ECS framework, making it easier to work with components and entities.