### PR TITLE
Provide random access to components in pre- and postflight for systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,16 @@ systems:
   - name: Physics
     phase: FixedUpdate
     context: true
-    run_after: []  # optional
+    run_after: []    # optional
+    preflight: true  # optional, extra scan before system run
+    postflight: true # optional, extra scan after system run
+    lookup:          # optional
+      - Particle     # request random access to particles in pre- or postflight
     inputs:
       - Velocity
     outputs:
       - Position
+
   - name: Render
     phase: Render
     manual: true        # Require manual call to world.apply_system_phase_render()

--- a/src/system.rs
+++ b/src/system.rs
@@ -46,6 +46,12 @@ pub struct System {
     /// Whether the system requires access to components of other entities, and which ones.
     #[serde(default)]
     pub lookup: Vec<ComponentRef>,
+    /// Whether the system uses a preflight phase.
+    #[serde(default)]
+    pub preflight: bool,
+    /// Whether the system uses a postflight phase.
+    #[serde(default)]
+    pub postflight: bool,
     /// The phase in which to run the system.
     pub phase: SystemPhaseRef,
     /// The optional input components to the system.

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,6 +1,6 @@
 use crate::Name;
 use crate::archetype::{Archetype, ArchetypeId, ArchetypeRef};
-use crate::component::ComponentName;
+use crate::component::{ComponentName, ComponentRef};
 use crate::state::StateName;
 use crate::system_scheduler::{Access, Dependency, Resource};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -43,6 +43,9 @@ pub struct System {
     /// Whether the system requires access to the user state (and which ones).
     #[serde(default, rename(serialize = "states", deserialize = "states"))]
     pub states: Vec<StateUse>,
+    /// Whether the system requires access to components of other entities, and which ones.
+    #[serde(default)]
+    pub lookup: Vec<ComponentRef>,
     /// The phase in which to run the system.
     pub phase: SystemPhaseRef,
     /// The optional input components to the system.

--- a/templates/systems.rs.jinja2
+++ b/templates/systems.rs.jinja2
@@ -377,8 +377,12 @@ pub trait Apply{{ system.name.type }}: System {
     ) -> Result<(), Self::Error> {
         Ok(())
     }
+    {%- if system.preflight %}
 
     /// Inspects all components before the actual operation starts.
+    ///
+    /// This function can be called multiple times, depending on the number of archetypes providing
+    /// the necessary components.
     ///
     /// ### Reads
     /// {% for input in system.inputs %}
@@ -387,7 +391,6 @@ pub trait Apply{{ system.name.type }}: System {
     /// ### Reads output to be mutated by the system
     /// {% for output in system.outputs %}
     /// - `{{ output.field }}`: A mutable slice of the components of type [`{{ output.type }}`].{% endfor %}
-    #[inline]
     #[allow(unused_variables)]
     fn preflight(
         &mut self,
@@ -416,12 +419,14 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.emits_commands %}
         commands: &impl WorldCommandSender
         {%- endif %}
-    ) {
-        // Intentionally left blank.
-        // TODO: Make optional
-    }
+    );
+    {%- endif %}
+    {%- if system.postflight %}
 
     /// Inspects all components after the actual operation finished.
+    ///
+    /// This function can be called multiple times, depending on the number of archetypes providing
+    /// the necessary components.
     ///
     /// ### Reads
     /// {% for input in system.inputs %}
@@ -430,7 +435,6 @@ pub trait Apply{{ system.name.type }}: System {
     /// ### Reads output to be mutated by the system
     /// {% for output in system.outputs %}
     /// - `{{ output.field }}`: A mutable slice of the components of type [`{{ output.type }}`].{% endfor %}
-    #[inline]
     #[allow(unused_variables)]
     fn postflight(
         &mut self,
@@ -459,10 +463,8 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.emits_commands %}
         commands: &impl WorldCommandSender
         {%- endif %}
-    ) {
-        // Intentionally left blank.
-        // TODO: Make optional
-    }
+    );
+    {%- endif %}
 
     /// Applies the system's business logic to the given entity components.
     ///

--- a/templates/systems.rs.jinja2
+++ b/templates/systems.rs.jinja2
@@ -323,6 +323,9 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
+        {%- if (system.lookup | count) > 0 %}
+        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -345,6 +348,9 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
+        {%- if (system.lookup | count) > 0 %}
+        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -367,6 +373,9 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
+        {%- if (system.lookup | count) > 0 %}
+        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -396,6 +405,9 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
+        {%- if (system.lookup | count) > 0 %}
+        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -433,6 +445,9 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
+        {%- if (system.lookup | count) > 0 %}
+        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -459,6 +474,9 @@ pub trait Apply{{ system.name.type }}: System {
                 {%- if system.needs_context %}
                 &context,
                 {%- endif %}
+                {%- if (system.lookup | count) > 0 %}
+                lookup,
+                {%- endif -%}
                 {%- for state in system.states %}
                 {{ state.use.field }},
                 {%- endfor %}
@@ -488,6 +506,9 @@ impl {{ system.name.type }} {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
+        {%- if (system.lookup | count) > 0 %}
+        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -513,6 +534,9 @@ impl {{ system.name.type }} {
             {%- if system.needs_context %}
             context,
             {%- endif %}
+            {%- if (system.lookup | count) > 0 %}
+            lookup,
+            {%- endif -%}
             {%- for state in system.states %}
             {{ state.use.field }},
             {%- endfor %}
@@ -546,6 +570,9 @@ impl {{ system.name.type }} {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
+        {%- if (system.lookup | count) > 0 %}
+        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -571,6 +598,9 @@ impl {{ system.name.type }} {
             {%- if system.needs_context %}
             context,
             {%- endif %}
+            {%- if (system.lookup | count) > 0 %}
+            lookup,
+            {%- endif -%}
             {%- for state in system.states %}
             {{ state.use.field }},
             {%- endfor %}
@@ -607,6 +637,9 @@ impl {{ system.name.type }} {
         {{ state.use.field }}: &{{ state.use.type }},
         {%- endif %}
         {%- endfor %}
+        {%- if (system.lookup | count) > 0 %}
+        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        {%- endif -%}
         {%- if system.emits_commands %}
         commands: &impl WorldCommandSender
         {%- endif %}
@@ -615,6 +648,9 @@ impl {{ system.name.type }} {
             {%- if system.needs_context %}
             &context,
             {%- endif %}
+            {%- if (system.lookup | count) > 0 %}
+            lookup,
+            {%- endif -%}
             {%- for state in system.states %}
             {{ state.use.field }},
             {%- endfor %}

--- a/templates/systems.rs.jinja2
+++ b/templates/systems.rs.jinja2
@@ -323,9 +323,6 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
-        {%- if (system.lookup | count) > 0 %}
-        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
-        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -348,9 +345,6 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
-        {%- if (system.lookup | count) > 0 %}
-        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
-        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -373,9 +367,6 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
-        {%- if (system.lookup | count) > 0 %}
-        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
-        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -491,9 +482,6 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
-        {%- if (system.lookup | count) > 0 %}
-        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
-        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -531,9 +519,6 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
-        {%- if (system.lookup | count) > 0 %}
-        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
-        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -560,9 +545,6 @@ pub trait Apply{{ system.name.type }}: System {
                 {%- if system.needs_context %}
                 &context,
                 {%- endif %}
-                {%- if (system.lookup | count) > 0 %}
-                lookup,
-                {%- endif -%}
                 {%- for state in system.states %}
                 {{ state.use.field }},
                 {%- endfor %}
@@ -592,9 +574,6 @@ impl {{ system.name.type }} {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
-        {%- if (system.lookup | count) > 0 %}
-        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
-        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -621,9 +600,6 @@ impl {{ system.name.type }} {
             {%- if system.needs_context %}
             context,
             {%- endif %}
-            {%- if (system.lookup | count) > 0 %}
-            lookup,
-            {%- endif -%}
             {%- for state in system.states %}
             {{ state.use.field }},
             {%- endfor %}
@@ -657,9 +633,6 @@ impl {{ system.name.type }} {
         {%- if system.needs_context %}
         context: &FrameContext,
         {%- endif %}
-        {%- if (system.lookup | count) > 0 %}
-        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
-        {%- endif -%}
         {%- for state in system.states %}
         {%- if state.write %}
         {{ state.use.field }}: &mut {{ state.use.type }},
@@ -686,9 +659,6 @@ impl {{ system.name.type }} {
             {%- if system.needs_context %}
             context,
             {%- endif %}
-            {%- if (system.lookup | count) > 0 %}
-            lookup,
-            {%- endif -%}
             {%- for state in system.states %}
             {{ state.use.field }},
             {%- endfor %}
@@ -725,9 +695,6 @@ impl {{ system.name.type }} {
         {{ state.use.field }}: &{{ state.use.type }},
         {%- endif %}
         {%- endfor %}
-        {%- if (system.lookup | count) > 0 %}
-        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
-        {%- endif -%}
         {%- if system.emits_commands %}
         commands: &impl WorldCommandSender
         {%- endif %}
@@ -736,9 +703,6 @@ impl {{ system.name.type }} {
             {%- if system.needs_context %}
             &context,
             {%- endif %}
-            {%- if (system.lookup | count) > 0 %}
-            lookup,
-            {%- endif -%}
             {%- for state in system.states %}
             {{ state.use.field }},
             {%- endfor %}

--- a/templates/systems.rs.jinja2
+++ b/templates/systems.rs.jinja2
@@ -668,5 +668,30 @@ impl core::ops::DerefMut for {{ system.name.type }} {
         &mut self.0
     }
 }
+{%- endfor %}
+{%- for system in ecs.systems %}
+{%- if (system.lookup | count) > 0 %}
 
+pub trait {{ system.name.raw }}ComponentLookup {
+    {%- for component in system.lookup %}
+    /// Gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
+    #[allow(dead_code, unused)]
+    fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}>;
+    {%- endfor %}
+}
+
+impl<T> {{ system.name.raw }}ComponentLookup for T
+where
+    T: ComponentAccess
+{
+{%- for component in system.lookup %}
+    /// Gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}> {
+        T::get_{{component.field}}_component(self, entity_id)
+    }
+    {%- endfor %}
+}
+{%- endif %}
 {%- endfor %}

--- a/templates/systems.rs.jinja2
+++ b/templates/systems.rs.jinja2
@@ -387,6 +387,92 @@ pub trait Apply{{ system.name.type }}: System {
         Ok(())
     }
 
+    /// Inspects all components before the actual operation starts.
+    ///
+    /// ### Reads
+    /// {% for input in system.inputs %}
+    /// - `{{ input.field }}`: A slice of the input components of type [`{{ input.type }}`].{% endfor %}
+    ///
+    /// ### Reads output to be mutated by the system
+    /// {% for output in system.outputs %}
+    /// - `{{ output.field }}`: A mutable slice of the components of type [`{{ output.type }}`].{% endfor %}
+    #[inline]
+    #[allow(unused_variables)]
+    fn preflight(
+        &mut self,
+        {%- if system.needs_context %}
+        context: &FrameContext,
+        {%- endif %}
+        {%- if (system.lookup | count) > 0 %}
+        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        {%- endif -%}
+        {%- for state in system.states %}
+        {%- if state.write %}
+        {{ state.use.field }}: &mut {{ state.use.type }},
+        {%- else %}
+        {{ state.use.field }}: &{{ state.use.type }},
+        {%- endif %}
+        {%- endfor %}
+        {%- if system.needs_entities %}
+        entities: &[EntityId],
+        {%- endif %}
+        {%- for input in system.inputs %}
+        {{ input.fields }}: &[{{ input.type }}],
+        {%- endfor %}
+        {%- for output in system.outputs %}
+        {{ output.fields }}: &[{{ output.type }}],
+        {%- endfor %}
+        {%- if system.emits_commands %}
+        commands: &impl WorldCommandSender
+        {%- endif %}
+    ) {
+        // Intentionally left blank.
+        // TODO: Make optional
+    }
+
+    /// Inspects all components after the actual operation finished.
+    ///
+    /// ### Reads
+    /// {% for input in system.inputs %}
+    /// - `{{ input.field }}`: A slice of the input components of type [`{{ input.type }}`].{% endfor %}
+    ///
+    /// ### Reads output to be mutated by the system
+    /// {% for output in system.outputs %}
+    /// - `{{ output.field }}`: A mutable slice of the components of type [`{{ output.type }}`].{% endfor %}
+    #[inline]
+    #[allow(unused_variables)]
+    fn postflight(
+        &mut self,
+        {%- if system.needs_context %}
+        context: &FrameContext,
+        {%- endif %}
+        {%- if (system.lookup | count) > 0 %}
+        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        {%- endif -%}
+        {%- for state in system.states %}
+        {%- if state.write %}
+        {{ state.use.field }}: &mut {{ state.use.type }},
+        {%- else %}
+        {{ state.use.field }}: &{{ state.use.type }},
+        {%- endif %}
+        {%- endfor %}
+        {%- if system.needs_entities %}
+        entities: &[EntityId],
+        {%- endif %}
+        {%- for input in system.inputs %}
+        {{ input.fields }}: &[{{ input.type }}],
+        {%- endfor %}
+        {%- for output in system.outputs %}
+        {{ output.fields }}: &[{{ output.type }}],
+        {%- endfor %}
+        {%- if system.emits_commands %}
+        commands: &impl WorldCommandSender
+        {%- endif %}
+    ) {
+        // Intentionally left blank.
+        // TODO: Make optional
+    }
+
     /// Applies the system's business logic to the given entity components.
     ///
     /// ### Performance Considerations
@@ -529,6 +615,7 @@ impl {{ system.name.type }} {
         commands: &impl WorldCommandSender
         {%- endif %}
     ) {
+        // Force the implementation of the Apply{{ system.name.type }} trait.
         Apply{{ system.name.type }}::apply_single(
             self,
             {%- if system.needs_context %}
@@ -593,6 +680,7 @@ impl {{ system.name.type }} {
         commands: &impl WorldCommandSender
         {%- endif %}
     ) {
+        // Force the implementation of the Apply{{ system.name.type }} trait.
         Apply{{ system.name.type }}::apply_many(
             self,
             {%- if system.needs_context %}

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -717,9 +717,6 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                {%- if system.needs_context %}
                &self.context,
                {%- endif %}
-               {%- if (system.lookup | count) > 0 %}
-               Box::new(&self.archetypes),
-               {%- endif -%}
                {%- for state in system.states %}
                {%- if state.write %}
                &mut self.states.{{ state.use.field }},
@@ -729,22 +726,19 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                {%- endfor %}
            );
         if is_ready && self.systems.{{ system.name.field }}.on_begin_phase(
-                    {%- if system.needs_context %}
-                    &self.context,
-                    {%- endif %}
-                    {%- if (system.lookup | count) > 0 %}
-                    Box::new(&self.archetypes),
-                    {%- endif -%}
-                    {%- for state in system.states %}
-                    {%- if state.write %}
-                    &mut self.states.{{ state.use.field }},
-                    {%- else %}
-                    &self.states.{{ state.use.field }},
-                    {%- endif %}
-                    {%- endfor %}
-                )
-                .inspect_err(|error| tracing::error!(?error, "{{ system.name.type }}::on_begin_phase returned an error"))
-                .is_ok()
+                {%- if system.needs_context %}
+                &self.context,
+                {%- endif %}
+                {%- for state in system.states %}
+                {%- if state.write %}
+                &mut self.states.{{ state.use.field }},
+                {%- else %}
+                &self.states.{{ state.use.field }},
+                {%- endif %}
+                {%- endfor %}
+            )
+            .inspect_err(|error| tracing::error!(?error, "{{ system.name.type }}::on_begin_phase returned an error"))
+            .is_ok()
         {
         {%- for archetype in system.affected_archetypes %}
             // Apply {{ system.name.type }} to {{ archetype.type }}
@@ -752,9 +746,6 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 {%- if system.needs_context %}
                 &self.context,
                 {%- endif %}
-                {%- if (system.lookup | count) > 0 %}
-                Box::new(&self.archetypes),
-                {%- endif -%}
                 {%- for state in system.states %}
                 {%- if state.write %}
                 &mut self.states.{{ state.use.field }},
@@ -781,9 +772,6 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 {%- if system.needs_context %}
                 &self.context,
                 {%- endif %}
-                {%- if (system.lookup | count) > 0 %}
-                Box::new(self),
-                {%- endif -%}
                 {%- for state in system.states %}
                 {%- if state.write %}
                 &mut self.states.{{ state.use.field }},
@@ -1249,7 +1237,7 @@ impl<E, Q> EntityAccess for {{ world.name.type }}<E, Q> {
         entity_id: EntityId
     ) -> Option<{{ archetype.name.raw }}EntityRef>
     {
-        self.archetypes.get_{{ archetype.name.field }}_entity(entity_id)
+        EntityAccess::get_{{ archetype.name.field }}_entity(&self.archetypes, entity_id)
     }
     {%- endfor %}
 }
@@ -1268,7 +1256,7 @@ impl<E, Q> EntityAccessMut for {{ world.name.type }}<E, Q> {
         entity_id: EntityId
     ) -> Option<{{ archetype.name.raw }}EntityMut>
     {
-        self.archetypes.get_{{ archetype.name.field }}_entity_mut(entity_id)
+        EntityAccessMut::get_{{ archetype.name.field }}_entity_mut(&mut self.archetypes, entity_id)
     }
     {%- endfor %}
 }
@@ -1283,7 +1271,7 @@ impl<E, Q> ComponentAccess for {{ world.name.type }}<E, Q> {
     #[allow(dead_code, unused)]
     #[inline]
     fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}> {
-        self.archetypes.get_{{component.field}}_component(entity_id)
+        ComponentAccess::get_{{component.field}}_component(&self.archetypes, entity_id)
     }
     {%- endfor %}
 }
@@ -1298,7 +1286,7 @@ impl<E, Q> ComponentAccessMut for {{ world.name.type }}<E, Q> {
     #[allow(dead_code, unused)]
     #[inline]
     fn get_{{component.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.type}}> {
-        self.archetypes.get_{{component.field}}_component_mut(entity_id)
+        ComponentAccessMut::get_{{component.field}}_component_mut(&mut self.archetypes, entity_id)
     }
     {%- endfor %}
 }

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -740,33 +740,112 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
             .inspect_err(|error| tracing::error!(?error, "{{ system.name.type }}::on_begin_phase returned an error"))
             .is_ok()
         {
-        {%- for archetype in system.affected_archetypes %}
-            // Apply {{ system.name.type }} to {{ archetype.type }}
-            self.systems.{{ system.name.field }}.apply_many(
-                {%- if system.needs_context %}
-                &self.context,
-                {%- endif %}
-                {%- for state in system.states %}
-                {%- if state.write %}
-                &mut self.states.{{ state.use.field }},
+            // Preflight
+            {
+                {%- if system.preflight %}
+                {%- for archetype in system.affected_archetypes %}
+                // Preflight of {{ system.name.type }} for {{ archetype.type }}
+                self.systems.{{ system.name.field }}.preflight(
+                    {%- if system.needs_context %}
+                    &self.context,
+                    {%- endif %}
+                    {%- if (system.lookup | count) > 0 %}
+                    Box::new(&self.archetypes),
+                    {%- endif -%}
+                    {%- for state in system.states %}
+                    {%- if state.write %}
+                    &mut self.states.{{ state.use.field }},
+                    {%- else %}
+                    &self.states.{{ state.use.field }},
+                    {%- endif %}
+                    {%- endfor %}
+                    {%- if system.needs_entities %}
+                    &self.archetypes.collection.{{ archetype.field }}.entities,
+                    {%- endif %}
+                    {%- for input in system.inputs %}
+                    &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
+                    {%- endfor %}
+                    {%- for output in system.outputs %}
+                    &self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
+                    {%- endfor %}
+                    {%- if system.emits_commands %}
+                    &self.command_queue
+                    {%- endif %}
+                );
+                {%- endfor %}
                 {%- else %}
-                &self.states.{{ state.use.field }},
+                // System has no preflight step
                 {%- endif %}
+            }
+
+            // Systems
+            {
+                {%- for archetype in system.affected_archetypes %}
+                // Apply {{ system.name.type }} to {{ archetype.type }}
+                self.systems.{{ system.name.field }}.apply_many(
+                    {%- if system.needs_context %}
+                    &self.context,
+                    {%- endif %}
+                    {%- for state in system.states %}
+                    {%- if state.write %}
+                    &mut self.states.{{ state.use.field }},
+                    {%- else %}
+                    &self.states.{{ state.use.field }},
+                    {%- endif %}
+                    {%- endfor %}
+                    {%- if system.needs_entities %}
+                    &self.archetypes.collection.{{ archetype.field }}.entities,
+                    {%- endif %}
+                    {%- for input in system.inputs %}
+                    &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
+                    {%- endfor %}
+                    {%- for output in system.outputs %}
+                    &mut self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
+                    {%- endfor %}
+                    {%- if system.emits_commands %}
+                    &self.command_queue
+                    {%- endif %}
+                );
                 {%- endfor %}
-                {%- if system.needs_entities %}
-                &self.archetypes.collection.{{ archetype.field }}.entities,
+            }
+
+            // Postflight
+            {
+                {%- if system.postflight %}
+                {%- for archetype in system.affected_archetypes %}
+                // Postflight of {{ system.name.type }} for {{ archetype.type }}
+                self.systems.{{ system.name.field }}.postflight(
+                    {%- if system.needs_context %}
+                    &self.context,
+                    {%- endif %}
+                    {%- if (system.lookup | count) > 0 %}
+                    Box::new(&self.archetypes),
+                    {%- endif -%}
+                    {%- for state in system.states %}
+                    {%- if state.write %}
+                    &mut self.states.{{ state.use.field }},
+                    {%- else %}
+                    &self.states.{{ state.use.field }},
+                    {%- endif %}
+                    {%- endfor %}
+                    {%- if system.needs_entities %}
+                    &self.archetypes.collection.{{ archetype.field }}.entities,
+                    {%- endif %}
+                    {%- for input in system.inputs %}
+                    &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
+                    {%- endfor %}
+                    {%- for output in system.outputs %}
+                    &self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
+                    {%- endfor %}
+                    {%- if system.emits_commands %}
+                    &self.command_queue
+                    {%- endif %}
+                );
+                {%- endfor %}
+                {%- else %}
+                // System has no preflight step
                 {%- endif %}
-                {%- for input in system.inputs %}
-                &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
-                {%- endfor %}
-                {%- for output in system.outputs %}
-                &mut self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
-                {%- endfor %}
-                {%- if system.emits_commands %}
-                &self.command_queue
-                {%- endif %}
-            );
-            {%- endfor %}
+            }
 
             self.systems.{{ system.name.field }}.on_end_phase(
                 {%- if system.needs_context %}
@@ -871,33 +950,112 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 {%- for system in group %}
                 if is_{{ system.name.field }}_ready {
                     s.spawn(|_| {
-                        {%- for archetype in system.affected_archetypes %}
-                        // Apply {{ system.name.type }} to {{ archetype.type }}
-                        self.systems.{{ system.name.field }}.apply_many(
-                            {%- if system.needs_context %}
-                            &self.context,
-                            {%- endif %}
-                            {%- for state in system.states %}
-                            {%- if state.write %}
-                            &mut self.states.{{ state.use.field }},
+                        // Preflight
+                        {
+                            {%- if system.preflight %}
+                            {%- for archetype in system.affected_archetypes %}
+                            // Preflight of {{ system.name.type }} for {{ archetype.type }}
+                            self.systems.{{ system.name.field }}.preflight(
+                                {%- if system.needs_context %}
+                                &self.context,
+                                {%- endif %}
+                                {%- if (system.lookup | count) > 0 %}
+                                Box::new(&self.archetypes),
+                                {%- endif -%}
+                                {%- for state in system.states %}
+                                {%- if state.write %}
+                                &mut self.states.{{ state.use.field }},
+                                {%- else %}
+                                &self.states.{{ state.use.field }},
+                                {%- endif %}
+                                {%- endfor %}
+                                {%- if system.needs_entities %}
+                                &self.archetypes.collection.{{ archetype.field }}.entities,
+                                {%- endif %}
+                                {%- for input in system.inputs %}
+                                &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
+                                {%- endfor %}
+                                {%- for output in system.outputs %}
+                                &self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
+                                {%- endfor %}
+                                {%- if system.emits_commands %}
+                                &self.command_queue
+                                {%- endif %}
+                            );
+                            {%- endfor %}
                             {%- else %}
-                            &self.states.{{ state.use.field }},
+                            // System has no preflight step
                             {%- endif %}
+                        }
+
+                        // Systems
+                        {
+                            {%- for archetype in system.affected_archetypes %}
+                            // Apply {{ system.name.type }} to {{ archetype.type }}
+                            self.systems.{{ system.name.field }}.apply_many(
+                                {%- if system.needs_context %}
+                                &self.context,
+                                {%- endif %}
+                                {%- for state in system.states %}
+                                {%- if state.write %}
+                                &mut self.states.{{ state.use.field }},
+                                {%- else %}
+                                &self.states.{{ state.use.field }},
+                                {%- endif %}
+                                {%- endfor %}
+                                {%- if system.needs_entities %}
+                                &self.archetypes.collection.{{ archetype.field }}.entities,
+                                {%- endif %}
+                                {%- for input in system.inputs %}
+                                &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
+                                {%- endfor %}
+                                {%- for output in system.outputs %}
+                                &mut self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
+                                {%- endfor %}
+                                {%- if system.emits_commands %}
+                                &self.command_queue
+                                {%- endif %}
+                            );
                             {%- endfor %}
-                            {%- if system.needs_entities %}
-                            &self.archetypes.collection.{{ archetype.field }}.entities,
+                        }
+
+                        // Postflight
+                        {
+                            {%- if system.postflight %}
+                            {%- for archetype in system.affected_archetypes %}
+                            // Postflight of {{ system.name.type }} for {{ archetype.type }}
+                            self.systems.{{ system.name.field }}.postflight(
+                                {%- if system.needs_context %}
+                                &self.context,
+                                {%- endif %}
+                                {%- if (system.lookup | count) > 0 %}
+                                Box::new(&self.archetypes),
+                                {%- endif -%}
+                                {%- for state in system.states %}
+                                {%- if state.write %}
+                                &mut self.states.{{ state.use.field }},
+                                {%- else %}
+                                &self.states.{{ state.use.field }},
+                                {%- endif %}
+                                {%- endfor %}
+                                {%- if system.needs_entities %}
+                                &self.archetypes.collection.{{ archetype.field }}.entities,
+                                {%- endif %}
+                                {%- for input in system.inputs %}
+                                &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
+                                {%- endfor %}
+                                {%- for output in system.outputs %}
+                                &self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
+                                {%- endfor %}
+                                {%- if system.emits_commands %}
+                                &self.command_queue
+                                {%- endif %}
+                            );
+                            {%- endfor %}
+                            {%- else %}
+                            // System has no preflight step
                             {%- endif %}
-                            {%- for input in system.inputs %}
-                            &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
-                            {%- endfor %}
-                            {%- for output in system.outputs %}
-                            &mut self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
-                            {%- endfor %}
-                            {%- if system.emits_commands %}
-                            &self.command_queue
-                            {%- endif %}
-                        );
-                        {%- endfor %}
+                        }
                     });
                 }
                 {%- endfor %}

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -769,6 +769,9 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                {%- if system.needs_context %}
                &self.context,
                {%- endif %}
+               {%- if (system.lookup | count) > 0 %}
+               Box::new(&self.archetypes),
+               {%- endif -%}
                {%- for state in system.states %}
                {%- if state.write %}
                &mut self.states.{{ state.use.field }},
@@ -781,6 +784,9 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                     {%- if system.needs_context %}
                     &self.context,
                     {%- endif %}
+                    {%- if (system.lookup | count) > 0 %}
+                    Box::new(&self.archetypes),
+                    {%- endif -%}
                     {%- for state in system.states %}
                     {%- if state.write %}
                     &mut self.states.{{ state.use.field }},
@@ -798,6 +804,9 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 {%- if system.needs_context %}
                 &self.context,
                 {%- endif %}
+                {%- if (system.lookup | count) > 0 %}
+                Box::new(&self.archetypes),
+                {%- endif -%}
                 {%- for state in system.states %}
                 {%- if state.write %}
                 &mut self.states.{{ state.use.field }},
@@ -824,6 +833,9 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 {%- if system.needs_context %}
                 &self.context,
                 {%- endif %}
+                {%- if (system.lookup | count) > 0 %}
+                Box::new(self),
+                {%- endif -%}
                 {%- for state in system.states %}
                 {%- if state.write %}
                 &mut self.states.{{ state.use.field }},
@@ -1242,7 +1254,7 @@ pub trait ComponentAccessMut: ComponentAccess {
 {%- for world in ecs.worlds %}
 
 //noinspection RsSortImplTraitMembers
-impl<E, Q> ComponentAccess for {{ world.name.type }}<E, Q> {
+impl ComponentAccess for {{ world.name.type }}Archetypes {
     {%- for component in world.components %}
 
     /// Gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
@@ -1257,7 +1269,7 @@ impl<E, Q> ComponentAccess for {{ world.name.type }}<E, Q> {
 {%- for world in ecs.worlds %}
 
 //noinspection RsSortImplTraitMembers
-impl<E, Q> ComponentAccessMut for {{ world.name.type }}<E, Q> {
+impl ComponentAccessMut for {{ world.name.type }} {
     {%- for component in world.components %}
 
     /// Mutably gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -200,13 +200,6 @@ pub struct {{ world.name.type }}<E, Q> {
     /// Flags for conditional phase execution.
     phase_flags: ConditionalPhaseFlags,
     {%- endif %}
-    /// The entity locator.
-    //
-    // Hashmap type not provided by design. Provide your own implementation such as fxhash::FxHashMap via type alias.
-    // Example:
-    //      type EntityLocationMap<K, V> = fxhash::FxHashMap<K, V>;
-    //
-    entity_locations: EntityLocationMap<EntityId, EntityArchetypeRef>,
     /// The frame context.
     context: FrameContext,
     {%- if ecs.any_phase_fixed %}
@@ -251,6 +244,20 @@ pub struct {{ world.name.type }}States {
 /// The archetypes used in the world.
 #[derive(Debug, Clone, Default)]
 struct {{ world.name.type }}Archetypes {
+    /// The entity locator.
+    //
+    // Hashmap type not provided by design. Provide your own implementation such as fxhash::FxHashMap via type alias.
+    // Example:
+    //      type EntityLocationMap<K, V> = fxhash::FxHashMap<K, V>;
+    //
+    entity_locations: EntityLocationMap<EntityId, EntityArchetypeRef>,
+
+    pub collection: {{ world.name.type }}ArchetypeCollection
+}
+
+/// The archetypes used in the world.
+#[derive(Debug, Clone, Default)]
+struct {{ world.name.type }}ArchetypeCollection {
     {%- for archetype in ecs.archetypes %}
     pub {{ archetype.name.field | snake_case }}: {{ archetype.name.type }},
     {%- endfor %}
@@ -365,7 +372,6 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 {{ system.name.field }}: CreateSystem::<{{ system.name.type }}>::create(create_systems),
                 {%- endfor %}
             },
-            entity_locations: Default::default(),
             {%- if ecs.any_phase_on_request %}
             phase_flags: ConditionalPhaseFlags::default(),
             {%- endif %}
@@ -393,12 +399,12 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
 
     /// Returns the overall number of entities in this world.
     pub fn len(&self) -> usize {
-        self.entity_locations.len()
+        self.archetypes.entity_locations.len()
     }
 
     /// Indicates whether there are no entities in this world.
     pub fn is_empty(&self) -> bool {
-        self.entity_locations.is_empty()
+        self.archetypes.entity_locations.is_empty()
     }
 
     /// De-spawns an entity given by its [`EntityId`]. Returns an error if the entity was unknown in this world.
@@ -415,37 +421,6 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     }
     {%- endif %}
     {%- endfor %}
-    {%- for component, archetypes in world.components|items %}
-
-    /// Gets the `{{component.raw}}` component of the specified entity.
-    #[allow(dead_code)]
-    #[inline]
-    pub fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}> {
-        let ear = self.entity_locations.get(&entity_id)?;
-        match ear.archetype {
-            {%- for archetype in archetypes %}
-            {{ archetype.type }}::ID => self.archetypes.{{ archetype.field }}.get_{{component.field}}_component_at(ear.index),
-            {%- endfor %}
-            #[allow(dead_code)]
-            _ => None
-        }
-    }
-
-    /// Mutably gets the `{{component.raw}}` component of the specified entity.
-    #[allow(dead_code)]
-    #[inline]
-    pub fn get_{{component.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.type}}> {
-        let ear = self.entity_locations.get(&entity_id)?;
-        match ear.archetype {
-            {%- for archetype in archetypes %}
-            {{ archetype.type }}::ID => self.archetypes.{{ archetype.field }}.get_{{component.field}}_component_at_mut(ear.index),
-            {%- endfor %}
-            #[allow(dead_code)]
-            _ => None
-        }
-    }
-
-    {%- endfor %}
     {%- for archetype in world.archetypes %}
 
     /// Accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
@@ -453,12 +428,12 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         &self,
         entity_id: EntityId
     ) -> Option<{{ archetype.name.raw }}EntityRef> {
-        let ear = self.entity_locations.get(&entity_id)?;
+        let ear = self.archetypes.entity_locations.get(&entity_id)?.clone();
         if ear.archetype != {{ archetype.name.type }}::ID {
             return None;
         }
-        self
-            .archetypes
+        self.archetypes
+            .collection
             .{{ archetype.name.field }}
             .get_entity_at(ear.index)
     }
@@ -468,12 +443,12 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         &mut self,
         entity_id: EntityId
     ) -> Option<{{ archetype.name.raw }}EntityMut> {
-        let ear = self.entity_locations.get(&entity_id)?;
+        let ear = self.archetypes.entity_locations.get(&entity_id)?.clone();
         if ear.archetype != {{ archetype.name.type }}::ID {
             return None;
         }
-        self
-            .archetypes
+        self.archetypes
+            .collection
             .{{ archetype.name.field }}
             .get_entity_at_mut(ear.index)
     }
@@ -508,12 +483,15 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
             }
         }
 
-        self.archetypes.{{ archetype.name.field }}
+        let registry = Registry(&mut self.archetypes.entity_locations);
+        self.archetypes
+            .collection
+            .{{ archetype.name.field }}
             .spawn_with(
                 {%- for component_name in archetype.components %}
                 {{component_name.field}},
                 {%- endfor %}
-                Registry(&mut self.entity_locations)
+                registry
             )
     }
     {%- endfor %}
@@ -815,13 +793,13 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 {%- endif %}
                 {%- endfor %}
                 {%- if system.needs_entities %}
-                &self.archetypes.{{ archetype.field }}.entities,
+                &self.archetypes.collection.{{ archetype.field }}.entities,
                 {%- endif %}
                 {%- for input in system.inputs %}
-                &self.archetypes.{{ archetype.field }}.{{ input.fields }},
+                &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
                 {%- endfor %}
                 {%- for output in system.outputs %}
-                &mut self.archetypes.{{ archetype.field }}.{{ output.fields }},
+                &mut self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
                 {%- endfor %}
                 {%- if system.emits_commands %}
                 &self.command_queue
@@ -949,13 +927,13 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                             {%- endif %}
                             {%- endfor %}
                             {%- if system.needs_entities %}
-                            &self.archetypes.{{ archetype.field }}.entities,
+                            &self.archetypes.collection.{{ archetype.field }}.entities,
                             {%- endif %}
                             {%- for input in system.inputs %}
-                            &self.archetypes.{{ archetype.field }}.{{ input.fields }},
+                            &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
                             {%- endfor %}
                             {%- for output in system.outputs %}
-                            &mut self.archetypes.{{ archetype.field }}.{{ output.fields }},
+                            &mut self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
                             {%- endfor %}
                             {%- if system.emits_commands %}
                             &self.command_queue
@@ -1048,11 +1026,12 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     }
 
     fn handle_despawn_command(&mut self, id: EntityId) -> Result<(), DespawnError> {
-         if let Some(loc) = self.entity_locations.remove(&id) {
+         if let Some(loc) = self.archetypes.entity_locations.remove(&id) {
             let result = match loc.archetype {
                 {%- for archetype in world.archetypes %}
                 {{ archetype.name.type }}::ID => {
                     self.archetypes
+                        .collection
                         .{{ archetype.name.field }}
                         .drop_at_index(loc.index)
                         .map_err(|index| DespawnError::InvalidIndexInArchetype(index, {{ archetype.name.type }}::ID))?
@@ -1064,7 +1043,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
             };
 
             if let Some(moved_entity) = result {
-                self.entity_locations.insert(moved_entity, EntityArchetypeRef {
+                self.archetypes.entity_locations.insert(moved_entity, EntityArchetypeRef {
                     archetype: loc.archetype,
                     index: loc.index
                 });
@@ -1173,9 +1152,10 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         previous_frontload_pivot: Option<usize>
     ) -> usize {
         self.archetypes
+            .collection
             .{{ archetype.name.field }}
             .frontload(
-                &mut self.entity_locations,
+                &mut self.archetypes.entity_locations,
                 entities_to_frontload,
                 previous_frontload_pivot
             )
@@ -1198,9 +1178,10 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         I: AsRef<[usize]>
     {
         self.archetypes
+            .collection
             .{{ archetype.name.field }}
             .frontload_by_indices_sorted(
-                &mut self.entity_locations,
+                &mut self.archetypes.entity_locations,
                 indices_to_frontload,
                 previous_frontload_pivot
             )
@@ -1218,9 +1199,10 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         for<'archetype> F: FnMut(&{{ archetype.name.raw }}EntityRef<'archetype>) -> bool,
     {
         self.archetypes
+            .collection
             .{{ archetype.name.field }}
             .frontload_scan(
-                &mut self.entity_locations,
+                &mut self.archetypes.entity_locations,
                 should_frontload
             )
     }
@@ -1254,14 +1236,14 @@ pub trait ComponentAccessMut: ComponentAccess {
 {%- for world in ecs.worlds %}
 
 //noinspection RsSortImplTraitMembers
-impl ComponentAccess for {{ world.name.type }}Archetypes {
+impl<E, Q> ComponentAccess for {{ world.name.type }}<E, Q> {
     {%- for component in world.components %}
 
     /// Gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
     #[allow(dead_code, unused)]
     #[inline]
     fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}> {
-        self.get_{{component.field}}_component(entity_id)
+        self.archetypes.get_{{component.field}}_component(entity_id)
     }
     {%- endfor %}
 }
@@ -1269,14 +1251,56 @@ impl ComponentAccess for {{ world.name.type }}Archetypes {
 {%- for world in ecs.worlds %}
 
 //noinspection RsSortImplTraitMembers
-impl ComponentAccessMut for {{ world.name.type }} {
+impl<E, Q> ComponentAccessMut for {{ world.name.type }}<E, Q> {
     {%- for component in world.components %}
 
     /// Mutably gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
     #[allow(dead_code, unused)]
     #[inline]
     fn get_{{component.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.type}}> {
-        self.get_{{component.field}}_component_mut(entity_id)
+        self.archetypes.get_{{component.field}}_component_mut(entity_id)
+    }
+    {%- endfor %}
+}
+{%- endfor %}
+{%- for world in ecs.worlds %}
+
+//noinspection RsSortImplTraitMembers
+impl ComponentAccess for {{ world.name.type }}Archetypes {
+    {%- for component, archetypes in world.components|items %}
+
+    /// Gets the `{{component.raw}}` component of the specified entity.
+    #[allow(dead_code)]
+    fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}> {
+        let ear = self.entity_locations.get(&entity_id)?.clone();
+        match ear.archetype {
+            {%- for archetype in archetypes %}
+            {{ archetype.type }}::ID => self.collection.{{ archetype.field }}.get_{{component.field}}_component_at(ear.index),
+            {%- endfor %}
+            #[allow(dead_code)]
+            _ => None
+        }
+    }
+    {%- endfor %}
+}
+{%- endfor %}
+{%- for world in ecs.worlds %}
+
+//noinspection RsSortImplTraitMembers
+impl ComponentAccessMut for {{ world.name.type }}Archetypes {
+    {%- for component, archetypes in world.components|items %}
+
+    /// Mutably gets the `{{component.raw}}` component of the specified entity.
+    #[allow(dead_code)]
+    fn get_{{component.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.type}}> {
+        let ear = self.entity_locations.get(&entity_id)?.clone();
+        match ear.archetype {
+            {%- for archetype in archetypes %}
+            {{ archetype.type }}::ID => self.collection.{{ archetype.field }}.get_{{component.field}}_component_at_mut(ear.index),
+            {%- endfor %}
+            #[allow(dead_code)]
+            _ => None
+        }
     }
     {%- endfor %}
 }

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -423,36 +423,6 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     {%- endfor %}
     {%- for archetype in world.archetypes %}
 
-    /// Accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
-    pub fn get_{{ archetype.name.field }}_entity(
-        &self,
-        entity_id: EntityId
-    ) -> Option<{{ archetype.name.raw }}EntityRef> {
-        let ear = self.archetypes.entity_locations.get(&entity_id)?.clone();
-        if ear.archetype != {{ archetype.name.type }}::ID {
-            return None;
-        }
-        self.archetypes
-            .collection
-            .{{ archetype.name.field }}
-            .get_entity_at(ear.index)
-    }
-
-    /// Mutably accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
-    pub fn get_{{ archetype.name.field }}_entity_mut(
-        &mut self,
-        entity_id: EntityId
-    ) -> Option<{{ archetype.name.raw }}EntityMut> {
-        let ear = self.archetypes.entity_locations.get(&entity_id)?.clone();
-        if ear.archetype != {{ archetype.name.type }}::ID {
-            return None;
-        }
-        self.archetypes
-            .collection
-            .{{ archetype.name.field }}
-            .get_entity_at_mut(ear.index)
-    }
-
     /// Spawn a new `{{ archetype.name.raw }}` entity into the world given its [`{{ archetype.name.raw }}EntityData`].
     #[inline]
     pub fn spawn_{{ archetype.name.field }}(
@@ -1233,6 +1203,76 @@ pub trait ComponentAccessMut: ComponentAccess {
     }
     {%- endfor %}
 }
+
+pub trait EntityAccess {
+    {%- for archetype in ecs.archetypes %}
+
+    /// Accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{ archetype.name.field }}_entity(
+        &self,
+        entity_id: EntityId
+    ) -> Option<{{ archetype.name.raw }}EntityRef>
+    {
+        None
+    }
+    {%- endfor %}
+}
+
+pub trait EntityAccessMut: EntityAccess {
+    {%- for archetype in ecs.archetypes %}
+
+    /// Mutably accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{ archetype.name.field }}_entity_mut(
+        &mut self,
+        entity_id: EntityId
+    ) -> Option<{{ archetype.name.raw }}EntityMut>
+    {
+        None
+    }
+    {%- endfor %}
+}
+{%- for world in ecs.worlds %}
+
+//noinspection RsSortImplTraitMembers
+impl<E, Q> EntityAccess for {{ world.name.type }}<E, Q> {
+    {%- for archetype in world.archetypes %}
+
+    /// Accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{ archetype.name.field }}_entity(
+        &self,
+        entity_id: EntityId
+    ) -> Option<{{ archetype.name.raw }}EntityRef>
+    {
+        self.archetypes.get_{{ archetype.name.field }}_entity(entity_id)
+    }
+    {%- endfor %}
+}
+{%- endfor %}
+{%- for world in ecs.worlds %}
+
+//noinspection RsSortImplTraitMembers
+impl<E, Q> EntityAccessMut for {{ world.name.type }}<E, Q> {
+    {%- for archetype in world.archetypes %}
+
+    /// Mutably accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{ archetype.name.field }}_entity_mut(
+        &mut self,
+        entity_id: EntityId
+    ) -> Option<{{ archetype.name.raw }}EntityMut>
+    {
+        self.archetypes.get_{{ archetype.name.field }}_entity_mut(entity_id)
+    }
+    {%- endfor %}
+}
+{%- endfor %}
 {%- for world in ecs.worlds %}
 
 //noinspection RsSortImplTraitMembers
@@ -1259,6 +1299,54 @@ impl<E, Q> ComponentAccessMut for {{ world.name.type }}<E, Q> {
     #[inline]
     fn get_{{component.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.type}}> {
         self.archetypes.get_{{component.field}}_component_mut(entity_id)
+    }
+    {%- endfor %}
+}
+{%- endfor %}
+{%- for world in ecs.worlds %}
+
+//noinspection RsSortImplTraitMembers
+impl EntityAccess for {{ world.name.type }}Archetypes {
+    {%- for archetype in world.archetypes %}
+
+    /// Accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
+    #[allow(dead_code, unused)]
+    fn get_{{ archetype.name.field }}_entity(
+        &self,
+        entity_id: EntityId
+    ) -> Option<{{ archetype.name.raw }}EntityRef>
+    {
+        let ear = self.entity_locations.get(&entity_id)?.clone();
+        if ear.archetype != {{ archetype.name.type }}::ID {
+            return None;
+        }
+        self.collection
+            .{{ archetype.name.field }}
+            .get_entity_at(ear.index)
+    }
+    {%- endfor %}
+}
+{%- endfor %}
+{%- for world in ecs.worlds %}
+
+//noinspection RsSortImplTraitMembers
+impl EntityAccessMut for {{ world.name.type }}Archetypes {
+    {%- for archetype in world.archetypes %}
+
+    /// Mutably accesses the `{{ archetype.name.raw }}` entity with the given ID if it exists in this archetype.
+    #[allow(dead_code, unused)]
+    fn get_{{ archetype.name.field }}_entity_mut(
+        &mut self,
+        entity_id: EntityId
+    ) -> Option<{{ archetype.name.raw }}EntityMut>
+    {
+        let ear = self.entity_locations.get(&entity_id)?.clone();
+        if ear.archetype != {{ archetype.name.type }}::ID {
+            return None;
+        }
+        self.collection
+            .{{ archetype.name.field }}
+            .get_entity_at_mut(ear.index)
     }
     {%- endfor %}
 }


### PR DESCRIPTION
This pull request introduces several enhancements to the system's functionality, including the addition of preflight and postflight phases, improved component access, and new trait implementations. The changes span multiple files and primarily focus on expanding system capabilities and improving code organization.

Enhancements to system functionality:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R104-R112): Added optional `preflight`, `postflight`, and `lookup` fields to the system's configuration.
* [`src/system.rs`](diffhunk://#diff-f39e72db88ddc6bc837b3421021b129ba50db0bbb5d3fdb93d9fb0883f1d18a5R46-R54): Introduced new fields `lookup`, `preflight`, and `postflight` in the `System` struct to support the new phases and component access.

Improvements to code organization and trait implementations:

* [`templates/systems.rs.jinja2`](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfR380-R467): Added `preflight` and `postflight` methods to the `Apply{{ system.name.type }}` trait, allowing systems to inspect components before and after the main operation.
* [`templates/systems.rs.jinja2`](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfR599): Implemented methods to force the `Apply{{ system.name.type }}` trait in system implementations, ensuring consistent behavior. [[1]](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfR599) [[2]](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfR658)
* [`templates/systems.rs.jinja2`](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfR761-R786): Introduced the `{{ system.name.raw }}ComponentLookup` trait for systems that require access to components of other entities, enhancing modularity and code reuse.