### PR TITLE
Remove apply_to from systems

### DIFF
--- a/templates/systems.rs.jinja2
+++ b/templates/systems.rs.jinja2
@@ -678,51 +678,6 @@ impl {{ system.name.type }} {
             {%- endif %}
         );
     }
-
-    {%- for archetype in system.affected_archetypes %}
-
-    /// Applies this system to the [`{{ archetype.type }}`].
-    #[inline]
-    #[deprecated]
-    fn apply_to_{{ archetype.field }}(
-        &mut self,
-        archetype: &mut {{ archetype.type }},
-        {%- if system.needs_context %}
-        context: &FrameContext,
-        {%- endif %}
-        {%- for state in system.states %}
-        {%- if state.write %}
-        {{ state.use.field }}: &mut {{ state.use.type }},
-        {%- else %}
-        {{ state.use.field }}: &{{ state.use.type }},
-        {%- endif %}
-        {%- endfor %}
-        {%- if system.emits_commands %}
-        commands: &impl WorldCommandSender
-        {%- endif %}
-    ) {
-        self.apply_many(
-            {%- if system.needs_context %}
-            &context,
-            {%- endif %}
-            {%- for state in system.states %}
-            {{ state.use.field }},
-            {%- endfor %}
-            {%- if system.needs_entities %}
-            &archetype.entities,
-            {%- endif %}
-            {%- for input in system.inputs %}
-            &archetype.{{ input.fields }},
-            {%- endfor %}
-            {%- for output in system.outputs %}
-            &mut archetype.{{ output.fields }},
-            {%- endfor %}
-            {%- if system.emits_commands %}
-            commands
-            {%- endif %}
-        );
-    }
-    {%- endfor %}
 }
 
 #[automatically_derived]


### PR DESCRIPTION
This pull request involves removing deprecated methods from the `templates/systems.rs.jinja2` file to clean up the codebase and improve maintainability. The most important changes include the removal of the `apply_to_*` methods for each affected archetype in the system.

Codebase cleanup:

* [`templates/systems.rs.jinja2`](diffhunk://#diff-2129ff96c7dd48a3b4dc8797918b8ef350633de78330b483b5f984a3b58296bfL681-L725): Removed deprecated `apply_to_*` methods for each affected archetype, which included inline annotations and the logic to apply the system to different archetypes.