### PR TITLE
Add support for user commands

### DIFF
--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -49,7 +49,7 @@ impl From<WorldId> for u64 {
 
 /// A command in the [`World`].
 #[allow(dead_code)]
-pub enum WorldCommand {
+pub enum WorldCommand<UserCommand> {
     /// Spawn an entity.
     ///
     /// # Note:
@@ -57,35 +57,47 @@ pub enum WorldCommand {
     SpawnEntity(ArchetypeEntityData),
     /// Despawn an entity.
     DespawnEntity(EntityId),
-    // TODO: Allow for user-specified commands.
+    /// A user-specific command.
+    User(UserCommand)
+}
+
+pub trait WorldUserCommand {
+    type UserCommand: core::marker::Send + core::fmt::Debug;
 }
 
 /// Sender of [`WorldCommand`] instances.
 #[allow(dead_code)]
-pub trait WorldCommandSender {
+pub trait WorldCommandSender: WorldUserCommand {
     type Error: core::error::Error;
 
     /// Sends a command. May block until sending is complete.
-    fn send(&self, command: WorldCommand) -> Result<(), Self::Error>;
+    fn send(&self, command: WorldCommand<Self::UserCommand>) -> Result<(), Self::Error>;
 }
 
 /// Sender of [`WorldCommand`] instances.
 #[allow(dead_code)]
-pub trait WorldCommandReceiver {
+pub trait WorldCommandReceiver: WorldUserCommand {
     type Error: core::error::Error;
 
     /// Attempts to receive a message from the channel without blocking.
     /// Returns [`Ok(None)`] if no command was queued.
-    fn recv(&self) -> Result<Option<WorldCommand>, Self::Error>;
+    fn recv(&self) -> Result<Option<WorldCommand<Self::UserCommand>>, Self::Error>;
+}
+
+/// Handler of a [`WorldCommand`]'s user command.
+#[allow(dead_code)]
+pub trait WorldUserCommandHandler: WorldUserCommand {
+    /// Handles a user command.
+    fn handle_user_command(&mut self, command: Self::UserCommand);
 }
 
 /// A sender and receiver of [`WorldCommand`] instances.
 #[allow(dead_code)]
 pub trait WorldCommandQueue: WorldCommandSender + WorldCommandReceiver { }
 
-impl<T> WorldCommandQueue for T
+impl<T, U> WorldCommandQueue for T
 where
-    T: WorldCommandSender + WorldCommandReceiver
+    T: WorldCommandSender<UserCommand = U> + WorldCommandReceiver<UserCommand = U>
 { }
 
 /// A frame context.
@@ -1103,6 +1115,15 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     }
     {%- endfor %}
 
+    /// Sends a command.
+    #[inline]
+    pub fn command(&mut self, command: WorldCommand<Q::UserCommand>) -> Result<(), Q::Error>
+    where
+        Q: WorldCommandSender
+    {
+        self.command_queue.send(command)
+    }
+
     /// Handles all queued commands.
     fn handle_commands(&mut self)
     where
@@ -1114,6 +1135,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                     match cmd {
                         WorldCommand::SpawnEntity(data) => self.handle_spawn_command(data),
                         WorldCommand::DespawnEntity(id) => self.handle_despawn_command(id).expect("Failed to despawn"),
+                        WorldCommand::User(cmd) => self.handle_user_command(cmd),
                     }
                 }
                 Ok(None) => break,
@@ -1124,6 +1146,15 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 }
             }
         }
+    }
+
+    #[inline]
+    fn handle_user_command(&mut self, data: <Q as WorldUserCommand>::UserCommand)
+    where
+        Q: WorldCommandReceiver,
+        Self: WorldUserCommandHandler<UserCommand = <Q as WorldUserCommand>::UserCommand>
+    {
+        WorldUserCommandHandler::handle_user_command(self, data);
     }
 
     fn handle_spawn_command(&mut self, data: ArchetypeEntityData) {
@@ -1537,5 +1568,15 @@ impl ComponentAccessMut for {{ world.name.type }}Archetypes {
         }
     }
     {%- endfor %}
+}
+{%- endfor %}
+{%- for world in ecs.worlds %}
+
+impl<E, Q, U> WorldUserCommand for {{ world.name.type }}<E, Q>
+where
+    Q: WorldUserCommand<UserCommand = U>,
+    U: core::marker::Send + core::fmt::Debug
+{
+    type UserCommand = U;
 }
 {%- endfor %}


### PR DESCRIPTION
This pull request introduces significant changes to the command queue system in the Rust ECS library to support user-specific commands. The most important changes include updates to the `README.md` to reflect the new functionality, and modifications to the command queue and world templates to handle user-specific commands.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15): Updated sections and examples to include user-specific commands in the command queue. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R157) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L167-R177) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L179-R192) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R201-R214)

Command queue enhancements:

* [`templates/world.rs.jinja2`](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbL52-R100): Modified `WorldCommand` enum to include a user-specific command variant and added the `WorldUserCommand` trait to handle these commands. [[1]](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbL52-R100) [[2]](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbR1118-R1126) [[3]](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbR1138) [[4]](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbR1151-R1159) [[5]](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbR1573-R1582)