### PR TITLE
Simplify state passing to world

### DIFF
--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -235,6 +235,10 @@ impl<E, Q> World for {{ world.name.type }}<E, Q> {
 {%- if (world.states | length) > 0 %}
 
 /// The user states used in the world.
+///
+/// It encapsulates ownership of and access to the following state types:
+/// {% for state in world.states %}
+/// - [{{ state.name.type }}]({{ state.name.type }}){%- endfor %}
 #[derive(Debug, Default)]
 pub struct {{ world.name.type }}States {
     {%- for state in world.states %}

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -251,6 +251,22 @@ pub struct {{ world.name.type }}States {
     pub {{ state.name.field }}: {{ state.name.type }},
     {%- endfor %}
 }
+
+impl {{ world.name.type }}States {
+    pub const fn new(
+        {%- for state in world.states %}
+        {{ state.name.field }}: {{ state.name.type }},
+        {%- endfor %}
+    ) -> Self {
+        Self {
+            {%- for state in world.states %}
+            {{ state.name.field }},
+            {%- endfor %}
+        }
+    }
+}
+
+
 {%- endif %}
 
 /// The archetypes used in the world.
@@ -340,9 +356,9 @@ impl<Q> {{ world.name.type }}<NoOpPhaseEvents, Q> {
     /// Creates a new [`{{ world.name.type }}`].
     pub fn new<S>(
         create_systems: &S,
-        {%- for state in world.states %}
-        {{ state.name.field }}: {{ state.name.type }},
-        {%- endfor %}
+        {%- if (world.states | length) > 0 %}
+        states: {{ world.name.type }}States,
+        {%- endif %}
         command_queue: Q) -> Self
     where
         S: CreateSystems,
@@ -350,9 +366,9 @@ impl<Q> {{ world.name.type }}<NoOpPhaseEvents, Q> {
     {
         Self::new_with_events(
             create_systems,
-            {%- for state in world.states %}
-            {{ state.name.field }},
-            {%- endfor %}
+            {%- if (world.states | length) > 0 %}
+            states,
+            {%- endif %}
             command_queue,
             NoOpPhaseEvents
         )
@@ -364,9 +380,9 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     /// Creates a new [`{{ world.name.type }}`].
     pub fn new_with_events<S>(
         create_systems: &S,
-        {%- for state in world.states %}
-        {{ state.name.field }}: {{ state.name.type }},
-        {%- endfor %}
+        {%- if (world.states | length) > 0 %}
+        states: {{ world.name.type }}States,
+        {%- endif %}
         command_queue: Q,
         phase_events: E) -> Self
     where
@@ -389,11 +405,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
             {%- endif %}
             context,
             {%- if (world.states | length) > 0 %}
-            states: {{ world.name.type }}States {
-                {%- for state in world.states %}
-                {{ state.name.field }},
-                {%- endfor %}
-            },
+            states,
             {%- endif %}
             {%- if ecs.any_phase_fixed %}
             fixed_accumulators: Default::default(),


### PR DESCRIPTION
This pull request refactors how world states are managed in the `templates/world.rs.jinja2` file by introducing a dedicated `{{ world.name.type }}States` struct. The changes simplify the initialization and handling of world states across multiple methods by consolidating state-related parameters into this new struct.

### Introduction of `{{ world.name.type }}States` struct:
* Added a new `{{ world.name.type }}States` struct with a `const fn new` method for initializing state fields. This encapsulates state-related fields into a single struct for better organization.

### Refactoring of constructors:
* Updated the `new` method in `impl<Q> {{ world.name.type }}<NoOpPhaseEvents, Q>` to replace individual state parameters with a single `{{ world.name.type }}States` parameter.
* Updated the `new_with_events` method in `impl<E, Q> {{ world.name.type }}<E, Q>` to accept `{{ world.name.type }}States` instead of individual state parameters.

### Simplification of state handling:
* Replaced inline initialization of states with direct usage of the `{{ world.name.type }}States` struct in the `new_with_events` method. This reduces redundancy and improves readability.