### PR TITLE
Add fine-grained state access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A silly little compile-time generated archetype ECS in Rust.
 
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Command Queue and Application-Specific Commands](#command-queue-and-application-specific-commands)
+    - [Command Queue and Application-Specific Commands](#command-queue-and-application-specific-commands)
 - [Examples](#examples)
-  - [WGPU Shader Compilation](#wgpu-shader-compilation)
+    - [WGPU Shader Compilation](#wgpu-shader-compilation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -100,10 +100,10 @@ systems:
   - name: Physics
     phase: FixedUpdate
     context: true
-    run_after: []    # optional
+    run_after: [ ]    # optional
     preflight: true  # optional, extra scan before system run
     postflight: true # optional, extra scan after system run
-    lookup:          # optional
+    lookup: # optional
       - Particle     # request random access to particles in pre- or postflight
     inputs:
       - Velocity
@@ -116,7 +116,11 @@ systems:
     # on_request: true  # call world.request_render_phase() to allow execution (resets atomically)
     states:
       - use: WgpuRender
-        write: false  # optional
+        write: false       # optional, defaults for the below 
+        check: read        # optional: none|read|write
+        begin_phase: none  # optional: none|read|write
+        system: write      # optional: none|read|write
+        end_phase: none    # optional: none|read|write
     inputs:
       - Position
 
@@ -166,14 +170,14 @@ impl<UserCommand> CommandQueue<UserCommand> {
 
 impl<UserCommand> WorldUserCommand for CommandQueue<UserCommand>
 where
-        UserCommand: Send + Debug
+    UserCommand: Send + Debug
 {
-  type UserCommand = UserCommand;
+    type UserCommand = UserCommand;
 }
 
 impl<UserCommand> WorldCommandReceiver for CommandQueue<UserCommand>
 where
-        UserCommand: Send + Debug
+    UserCommand: Send + Debug
 {
     type Error = TryRecvError;
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -96,12 +96,12 @@ pub struct StateUse {
     /// Whether write access is required.
     #[serde(default)]
     pub write: bool,
-    /// How the phase begin hook accesses the state.
-    #[serde(default)]
-    pub begin_phase: Option<AccessType>,
     /// How the readiness check accesses the state.
     #[serde(default)]
     pub check: Option<AccessType>,
+    /// How the phase begin hook accesses the state.
+    #[serde(default)]
+    pub begin_phase: Option<AccessType>,
     /// How the preflight accesses the state.
     #[serde(default)]
     pub preflight: Option<AccessType>,
@@ -153,52 +153,26 @@ impl System {
         }
     }
 
+    fn default_state_access(state: &mut Option<AccessType>, write: bool) {
+        if state.is_none() {
+            *state = Some(if write {
+                AccessType::Write
+            } else {
+                AccessType::Read
+            });
+        }
+    }
+
     pub(crate) fn finish(&mut self, archetypes: &[Archetype]) {
         self.finish_dependencies();
 
         for state in &mut self.states {
-            if state.begin_phase.is_none() {
-                state.begin_phase = Some(if state.write {
-                    AccessType::Write
-                } else {
-                    AccessType::Read
-                });
-            }
-            if state.check.is_none() {
-                state.check = Some(if state.write {
-                    AccessType::Write
-                } else {
-                    AccessType::Read
-                });
-            }
-            if state.preflight.is_none() {
-                state.preflight = Some(if state.write {
-                    AccessType::Write
-                } else {
-                    AccessType::Read
-                });
-            }
-            if state.system.is_none() {
-                state.system = Some(if state.write {
-                    AccessType::Write
-                } else {
-                    AccessType::Read
-                });
-            }
-            if state.postflight.is_none() {
-                state.postflight = Some(if state.write {
-                    AccessType::Write
-                } else {
-                    AccessType::Read
-                });
-            }
-            if state.end_phase.is_none() {
-                state.end_phase = Some(if state.write {
-                    AccessType::Write
-                } else {
-                    AccessType::Read
-                });
-            }
+            Self::default_state_access(&mut state.check, state.write);
+            Self::default_state_access(&mut state.begin_phase, state.write);
+            Self::default_state_access(&mut state.preflight, state.write);
+            Self::default_state_access(&mut state.system, state.write);
+            Self::default_state_access(&mut state.postflight, state.write);
+            Self::default_state_access(&mut state.end_phase, state.write);
         }
 
         let mut ids_and_names = Vec::new();

--- a/src/system_scheduler.rs
+++ b/src/system_scheduler.rs
@@ -278,6 +278,8 @@ mod tests {
             run_after: prefer_after.into_iter().map(sysname).collect(),
             context: false,
             states: vec![],
+            lookup: vec![],
+            preflight: false,
             entities: false,
             commands: false,
             inputs: inputs.into_iter().map(compname).collect(),
@@ -290,6 +292,7 @@ mod tests {
             component_untuple_code: String::new(),
             description: None,
             dependencies: Default::default(),
+            postflight: false,
         };
         system.finish_dependencies();
         system

--- a/templates/systems.rs.jinja2
+++ b/templates/systems.rs.jinja2
@@ -324,11 +324,16 @@ pub trait Apply{{ system.name.type }}: System {
         context: &FrameContext,
         {%- endif %}
         {%- for state in system.states %}
-        {%- if state.write %}
-        {{ state.use.field }}: &mut {{ state.use.type }},
-        {%- else %}
-        {{ state.use.field }}: &{{ state.use.type }},
-        {%- endif %}
+            {%- set access = state.check | default(value="none") %}
+            {%- if access == "none" %}
+                {# skip #}
+            {%- elif access == "read" %}
+                {{ state.use.field }}: &{{ state.use.type }},
+            {%- elif access == "write" %}
+                {{ state.use.field }}: &mut {{ state.use.type }},
+            {%- else %}
+                todo!("Invalid state use in ECS construction")
+            {%- endif %}
         {%- endfor %}
     ) -> bool {
         true
@@ -346,11 +351,16 @@ pub trait Apply{{ system.name.type }}: System {
         context: &FrameContext,
         {%- endif %}
         {%- for state in system.states %}
-        {%- if state.write %}
-        {{ state.use.field }}: &mut {{ state.use.type }},
-        {%- else %}
-        {{ state.use.field }}: &{{ state.use.type }},
-        {%- endif %}
+            {%- set access = state.begin_phase | default(value="none") %}
+            {%- if access == "none" %}
+                {# skip #}
+            {%- elif access == "read" %}
+                {{ state.use.field }}: &{{ state.use.type }},
+            {%- elif access == "write" %}
+                {{ state.use.field }}: &mut {{ state.use.type }},
+            {%- else %}
+                todo!("Invalid state use in ECS construction")
+            {%- endif %}
         {%- endfor %}
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -368,11 +378,16 @@ pub trait Apply{{ system.name.type }}: System {
         context: &FrameContext,
         {%- endif %}
         {%- for state in system.states %}
-        {%- if state.write %}
-        {{ state.use.field }}: &mut {{ state.use.type }},
-        {%- else %}
-        {{ state.use.field }}: &{{ state.use.type }},
-        {%- endif %}
+            {%- set access = state.end_phase | default(value="none") %}
+            {%- if access == "none" %}
+                {# skip #}
+            {%- elif access == "read" %}
+                {{ state.use.field }}: &{{ state.use.type }},
+            {%- elif access == "write" %}
+                {{ state.use.field }}: &mut {{ state.use.type }},
+            {%- else %}
+                todo!("Invalid state use in ECS construction")
+            {%- endif %}
         {%- endfor %}
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -401,11 +416,16 @@ pub trait Apply{{ system.name.type }}: System {
         lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
         {%- endif -%}
         {%- for state in system.states %}
-        {%- if state.write %}
-        {{ state.use.field }}: &mut {{ state.use.type }},
-        {%- else %}
-        {{ state.use.field }}: &{{ state.use.type }},
-        {%- endif %}
+            {%- set access = state.preflight | default(value="none") %}
+            {%- if access == "none" %}
+                {# skip #}
+            {%- elif access == "read" %}
+                {{ state.use.field }}: &{{ state.use.type }},
+            {%- elif access == "write" %}
+                {{ state.use.field }}: &mut {{ state.use.type }},
+            {%- else %}
+                todo!("Invalid state use in ECS construction")
+            {%- endif %}
         {%- endfor %}
         {%- if system.needs_entities %}
         entities: &[EntityId],
@@ -444,13 +464,16 @@ pub trait Apply{{ system.name.type }}: System {
         {%- if (system.lookup | count) > 0 %}
         lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
         {%- endif -%}
-        {%- for state in system.states %}
-        {%- if state.write %}
-        {{ state.use.field }}: &mut {{ state.use.type }},
+        {%- set access = state.postflight | default(value="none") %}
+        {%- if access == "none" %}
+            {# skip #}
+        {%- elif access == "read" %}
+            {{ state.use.field }}: &{{ state.use.type }},
+        {%- elif access == "write" %}
+            {{ state.use.field }}: &mut {{ state.use.type }},
         {%- else %}
-        {{ state.use.field }}: &{{ state.use.type }},
+            todo!("Invalid state use in ECS construction")
         {%- endif %}
-        {%- endfor %}
         {%- if system.needs_entities %}
         entities: &[EntityId],
         {%- endif %}
@@ -485,11 +508,16 @@ pub trait Apply{{ system.name.type }}: System {
         context: &FrameContext,
         {%- endif %}
         {%- for state in system.states %}
-        {%- if state.write %}
-        {{ state.use.field }}: &mut {{ state.use.type }},
-        {%- else %}
-        {{ state.use.field }}: &{{ state.use.type }},
-        {%- endif %}
+            {%- set access = state.system | default(value="none") %}
+            {%- if access == "none" %}
+                {# skip #}
+            {%- elif access == "read" %}
+                {{ state.use.field }}: &{{ state.use.type }},
+            {%- elif access == "write" %}
+                {{ state.use.field }}: &mut {{ state.use.type }},
+            {%- else %}
+                todo!("Invalid state use in ECS construction")
+            {%- endif %}
         {%- endfor %}
         {%- if system.needs_entities %}
         entity: EntityId,
@@ -522,11 +550,16 @@ pub trait Apply{{ system.name.type }}: System {
         context: &FrameContext,
         {%- endif %}
         {%- for state in system.states %}
-        {%- if state.write %}
-        {{ state.use.field }}: &mut {{ state.use.type }},
-        {%- else %}
-        {{ state.use.field }}: &{{ state.use.type }},
-        {%- endif %}
+            {%- set access = state.system | default(value="none") %}
+            {%- if access == "none" %}
+                {# skip #}
+            {%- elif access == "read" %}
+                {{ state.use.field }}: &{{ state.use.type }},
+            {%- elif access == "write" %}
+                {{ state.use.field }}: &mut {{ state.use.type }},
+            {%- else %}
+                todo!("Invalid state use in ECS construction")
+            {%- endif %}
         {%- endfor %}
         {%- if system.needs_entities %}
         entities: &[EntityId],

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -746,11 +746,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                &self.context,
                {%- endif %}
                {%- for state in system.states %}
-               {%- if state.write %}
-               &mut self.states.{{ state.use.field }},
-               {%- else %}
-               &self.states.{{ state.use.field }},
-               {%- endif %}
+                   {%- set access = state.check | default(value="none") %}
+                   {%- if access == "none" %}
+                       {# skip #}
+                   {%- elif access == "read" %}
+                       &self.states.{{ state.use.field }},
+                   {%- elif access == "write" %}
+                       &mut self.states.{{ state.use.field }},
+                   {%- else %}
+                       todo!("Invalid state use in ECS construction")
+                   {%- endif %}
                {%- endfor %}
            );
         if is_ready && self.systems.{{ system.name.field }}.on_begin_phase(
@@ -758,11 +763,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 &self.context,
                 {%- endif %}
                 {%- for state in system.states %}
-                {%- if state.write %}
-                &mut self.states.{{ state.use.field }},
-                {%- else %}
-                &self.states.{{ state.use.field }},
-                {%- endif %}
+                    {%- set access = state.begin_phase | default(value="none") %}
+                    {%- if access == "none" %}
+                        {# skip #}
+                    {%- elif access == "read" %}
+                        &self.states.{{ state.use.field }},
+                    {%- elif access == "write" %}
+                        &mut self.states.{{ state.use.field }},
+                    {%- else %}
+                        todo!("Invalid state use in ECS construction")
+                    {%- endif %}
                 {%- endfor %}
             )
             .inspect_err(|error| tracing::error!(?error, "{{ system.name.type }}::on_begin_phase returned an error"))
@@ -781,11 +791,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                     Box::new(&self.archetypes),
                     {%- endif -%}
                     {%- for state in system.states %}
-                    {%- if state.write %}
-                    &mut self.states.{{ state.use.field }},
-                    {%- else %}
-                    &self.states.{{ state.use.field }},
-                    {%- endif %}
+                        {%- set access = state.preflight | default(value="none") %}
+                        {%- if access == "none" %}
+                            {# skip #}
+                        {%- elif access == "read" %}
+                            &self.states.{{ state.use.field }},
+                        {%- elif access == "write" %}
+                            &mut self.states.{{ state.use.field }},
+                        {%- else %}
+                            todo!("Invalid state use in ECS construction")
+                        {%- endif %}
                     {%- endfor %}
                     {%- if system.needs_entities %}
                     &self.archetypes.collection.{{ archetype.field }}.entities,
@@ -815,11 +830,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                     &self.context,
                     {%- endif %}
                     {%- for state in system.states %}
-                    {%- if state.write %}
-                    &mut self.states.{{ state.use.field }},
-                    {%- else %}
-                    &self.states.{{ state.use.field }},
-                    {%- endif %}
+                        {%- set access = state.system | default(value="none") %}
+                        {%- if access == "none" %}
+                            {# skip #}
+                        {%- elif access == "read" %}
+                            &self.states.{{ state.use.field }},
+                        {%- elif access == "write" %}
+                            &mut self.states.{{ state.use.field }},
+                        {%- else %}
+                            todo!("Invalid state use in ECS construction")
+                        {%- endif %}
                     {%- endfor %}
                     {%- if system.needs_entities %}
                     &self.archetypes.collection.{{ archetype.field }}.entities,
@@ -850,11 +870,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                     Box::new(&self.archetypes),
                     {%- endif -%}
                     {%- for state in system.states %}
-                    {%- if state.write %}
-                    &mut self.states.{{ state.use.field }},
-                    {%- else %}
-                    &self.states.{{ state.use.field }},
-                    {%- endif %}
+                        {%- set access = state.postflight | default(value="none") %}
+                        {%- if access == "none" %}
+                            {# skip #}
+                        {%- elif access == "read" %}
+                            &self.states.{{ state.use.field }},
+                        {%- elif access == "write" %}
+                            &mut self.states.{{ state.use.field }},
+                        {%- else %}
+                            todo!("Invalid state use in ECS construction")
+                        {%- endif %}
                     {%- endfor %}
                     {%- if system.needs_entities %}
                     &self.archetypes.collection.{{ archetype.field }}.entities,
@@ -880,11 +905,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 &self.context,
                 {%- endif %}
                 {%- for state in system.states %}
-                {%- if state.write %}
-                &mut self.states.{{ state.use.field }},
-                {%- else %}
-                &self.states.{{ state.use.field }},
-                {%- endif %}
+                    {%- set access = state.end_phase | default(value="none") %}
+                    {%- if access == "none" %}
+                        {# skip #}
+                    {%- elif access == "read" %}
+                        &self.states.{{ state.use.field }},
+                    {%- elif access == "write" %}
+                        &mut self.states.{{ state.use.field }},
+                    {%- else %}
+                        todo!("Invalid state use in ECS construction")
+                    {%- endif %}
                 {%- endfor %}
             )
             .inspect_err(|error| tracing::error!(?error, "{{ system.name.type }}::on_end_phase returned an error"))
@@ -948,11 +978,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                &self.context,
                {%- endif %}
                {%- for state in system.states %}
-               {%- if state.write %}
-               &mut self.states.{{ state.use.field }},
-               {%- else %}
-               &self.states.{{ state.use.field }},
-               {%- endif %}
+                   {%- set access = state.check | default(value="none") %}
+                   {%- if access == "none" %}
+                       {# skip #}
+                   {%- elif access == "read" %}
+                       &self.states.{{ state.use.field }},
+                   {%- elif access == "write" %}
+                       &mut self.states.{{ state.use.field }},
+                   {%- else %}
+                       todo!("Invalid state use in ECS construction")
+                   {%- endif %}
                {%- endfor %}
            );
         let is_{{ system.name.field }}_ready = is_{{ system.name.field }}_ready &
@@ -961,11 +996,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                 &self.context,
                 {%- endif %}
                 {%- for state in system.states %}
-                {%- if state.write %}
-                &mut self.states.{{ state.use.field }},
-                {%- else %}
-                &self.states.{{ state.use.field }},
-                {%- endif %}
+                    {%- set access = state.begin_phase | default(value="none") %}
+                    {%- if access == "none" %}
+                        {# skip #}
+                    {%- elif access == "read" %}
+                        &self.states.{{ state.use.field }},
+                    {%- elif access == "write" %}
+                        &mut self.states.{{ state.use.field }},
+                    {%- else %}
+                        todo!("Invalid state use in ECS construction")
+                    {%- endif %}
                 {%- endfor %}
             )
             .inspect_err(|error| tracing::error!(%error, "{{ system.name.type }}::on_begin_phase returned an error"))
@@ -991,11 +1031,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                                 Box::new(&self.archetypes),
                                 {%- endif -%}
                                 {%- for state in system.states %}
-                                {%- if state.write %}
-                                &mut self.states.{{ state.use.field }},
-                                {%- else %}
-                                &self.states.{{ state.use.field }},
-                                {%- endif %}
+                                    {%- set access = state.preflight | default(value="none") %}
+                                    {%- if access == "none" %}
+                                        {# skip #}
+                                    {%- elif access == "read" %}
+                                        &self.states.{{ state.use.field }},
+                                    {%- elif access == "write" %}
+                                        &mut self.states.{{ state.use.field }},
+                                    {%- else %}
+                                        todo!("Invalid state use in ECS construction")
+                                    {%- endif %}
                                 {%- endfor %}
                                 {%- if system.needs_entities %}
                                 &self.archetypes.collection.{{ archetype.field }}.entities,
@@ -1025,11 +1070,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                                 &self.context,
                                 {%- endif %}
                                 {%- for state in system.states %}
-                                {%- if state.write %}
-                                &mut self.states.{{ state.use.field }},
-                                {%- else %}
-                                &self.states.{{ state.use.field }},
-                                {%- endif %}
+                                    {%- set access = state.system | default(value="none") %}
+                                    {%- if access == "none" %}
+                                        {# skip #}
+                                    {%- elif access == "read" %}
+                                        &self.states.{{ state.use.field }},
+                                    {%- elif access == "write" %}
+                                        &mut self.states.{{ state.use.field }},
+                                    {%- else %}
+                                        todo!("Invalid state use in ECS construction")
+                                    {%- endif %}
                                 {%- endfor %}
                                 {%- if system.needs_entities %}
                                 &self.archetypes.collection.{{ archetype.field }}.entities,
@@ -1056,15 +1106,20 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                                 {%- if system.needs_context %}
                                 &self.context,
                                 {%- endif %}
-                                {%- if (system.lookup | count) > 0 %}
+                                {%- if (system.lookup | preflightcount) > 0 %}
                                 Box::new(&self.archetypes),
                                 {%- endif -%}
                                 {%- for state in system.states %}
-                                {%- if state.write %}
-                                &mut self.states.{{ state.use.field }},
-                                {%- else %}
-                                &self.states.{{ state.use.field }},
-                                {%- endif %}
+                                    {%- set access = state.postflight | default(value="none") %}
+                                    {%- if access == "none" %}
+                                        {# skip #}
+                                    {%- elif access == "read" %}
+                                        &self.states.{{ state.use.field }},
+                                    {%- elif access == "write" %}
+                                        &mut self.states.{{ state.use.field }},
+                                    {%- else %}
+                                        todo!("Invalid state use in ECS construction")
+                                    {%- endif %}
                                 {%- endfor %}
                                 {%- if system.needs_entities %}
                                 &self.archetypes.collection.{{ archetype.field }}.entities,
@@ -1096,11 +1151,16 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
             &self.context,
             {%- endif %}
             {%- for state in system.states %}
-            {%- if state.write %}
-            &mut self.states.{{ state.use.field }},
-            {%- else %}
-            &self.states.{{ state.use.field }},
-            {%- endif %}
+                {%- set access = state.end_phase | default(value="none") %}
+                {%- if access == "none" %}
+                    {# skip #}
+                {%- elif access == "read" %}
+                    &self.states.{{ state.use.field }},
+                {%- elif access == "write" %}
+                    &mut self.states.{{ state.use.field }},
+                {%- else %}
+                    todo!("Invalid state use in ECS construction")
+                {%- endif %}
             {%- endfor %}
         )
         .inspect_err(|error| tracing::error!(%error, "{{ system.name.type }}::on_end_phase returned an error"))


### PR DESCRIPTION
This pull request introduces a new `AccessType` enum to define access levels (`None`, `Read`, `Write`) for various system phases in an ECS framework. It updates the `System` and `StateUse` structures to support these access types, modifies templates to handle the new access logic, and ensures default values are assigned during system initialization. The changes enhance flexibility and clarity in how states are accessed across different phases of system execution.

### Core Enhancements to System Access:

* **New `AccessType` Enum**: Introduced the `AccessType` enum with variants `None`, `Read`, and `Write` to standardize access levels for system states. (`src/system.rs`, [src/system.rsR14-R21](diffhunk://#diff-f39e72db88ddc6bc837b3421021b129ba50db0bbb5d3fdb93d9fb0883f1d18a5R14-R21))
* **Expanded `StateUse` Struct**: Added optional fields (`begin_phase`, `check`, `preflight`, `system`, `postflight`, `end_phase`) to the `StateUse` struct, each representing access types for different phases of system execution. (`src/system.rs`, [src/system.rsR99-R116](diffhunk://#diff-f39e72db88ddc6bc837b3421021b129ba50db0bbb5d3fdb93d9fb0883f1d18a5R99-R116))

### Default Access Logic:

* **Default Assignment in `System` Initialization**: Implemented logic in the `System::finish` method to assign default `AccessType` values based on the `write` field if not explicitly provided. (`src/system.rs`, [src/system.rsR159-R203](diffhunk://#diff-f39e72db88ddc6bc837b3421021b129ba50db0bbb5d3fdb93d9fb0883f1d18a5R159-R203))

### Template Updates for Code Generation:

* **State Access in Templates**: Updated templates (`templates/systems.rs.jinja2` and `templates/world.rs.jinja2`) to conditionally generate code based on the `AccessType` for various phases (`check`, `begin_phase`, `preflight`, `system`, `postflight`, `end_phase`). This ensures correct handling of `Read` and `Write` access and skips states with `None`. (`templates/systems.rs.jinja2`, F786dc5dL324R550; `templates/world.rs.jinja2`, F6912ac7L746R1031)

### Test and Scheduler Adjustments:

* **Test Struct Updates**: Added fields like `lookup`, `preflight`, and `postflight` to test-related structures to align with the new access logic. (`src/system_scheduler.rs`, F5230899L278R292)

These changes collectively enhance the ECS framework's configurability and maintainability by introducing a clear and extensible model for state access management.