### PR TITLE
Simplify entity spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ In your world, you can now instantiate shaders and get them back:
 ```rust
 fn register_example_shader<E, Q>(world: &MainWorld<E, Q>) -> WgpuShaderEntityRef {
     let entity_id = world.spawn_wgpu_shader(WgpuShaderEntityData {
-        wgpu_shader: WgpuShaderData::new(include_wgsl!("shader.wgsl")).into(),
+        wgpu_shader: WgpuShaderData::new(include_wgsl!("shader.wgsl")),
     });
 
     // Get it back

--- a/templates/archetypes.rs.jinja2
+++ b/templates/archetypes.rs.jinja2
@@ -261,18 +261,41 @@ pub struct {{ archetype.name.type }} {
 }
 
 /// An entity of the [`{{ archetype.name.type }}`].
-pub type {{ archetype.name.raw }}Entity = EntityWithIdAndData<{{ archetype.name.raw }}EntityData>;
+pub type {{ archetype.name.raw }}Entity = EntityWithIdAndData<{{ archetype.name.raw }}EntityComponents>;
+
+/// The data of an entity of the [`{{ archetype.name.type }}`].
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct {{ archetype.name.raw }}EntityData {
+    {%- for component_name in archetype.components %}
+    pub {{ component_name.field }}: {{ component_name.raw }}Data,
+    {%- endfor %}
+}
 
 /// An entity of the [`{{ archetype.name.type }}`].
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub struct {{ archetype.name.raw }}EntityData {
+pub struct {{ archetype.name.raw }}EntityComponents {
     {%- for component_name in archetype.components %}
     pub {{ component_name.field }}: {{ component_name.type }},
     {%- endfor %}
 }
 
+impl From<{{ archetype.name.raw }}EntityData> for {{ archetype.name.raw }}EntityComponents {
+    fn from(value: {{ archetype.name.raw }}EntityData) -> Self {
+        Self {
+            {%- for component_name in archetype.components %}
+            {{ component_name.field }}: value.{{ component_name.field }}.into(),
+            {%- endfor %}
+        }
+    }
+}
+
 impl EntityData for {{ archetype.name.raw }}EntityData {
+    const ARCHETYPE_ID: ArchetypeId = {{archetype.name.type}}::ID;
+}
+
+impl EntityData for {{ archetype.name.raw }}EntityComponents {
     const ARCHETYPE_ID: ArchetypeId = {{archetype.name.type}}::ID;
 }
 
@@ -469,7 +492,7 @@ impl HasComponent<{{ component_name.type }}> for {{ archetype.name.raw }}Entity 
 }
 
 #[allow(dead_code)]
-impl HasComponent<{{ component_name.type }}> for {{ archetype.name.raw }}EntityData {
+impl HasComponent<{{ component_name.type }}> for {{ archetype.name.raw }}EntityComponents {
     #[inline]
     fn get(&self) -> &{{ component_name.type }} {
         &self.{{ component_name.field }}
@@ -487,14 +510,26 @@ impl {{ archetype.name.raw }}EntityData {
     #[allow(dead_code)]
     pub fn spawn_into<W>(self, world: &mut W) -> EntityId
     where
-        W: Spawn<{{ archetype.name.raw}}EntityData>
+        W: Spawn<{{ archetype.name.raw }}EntityData>
+    {
+        world.spawn(self)
+    }
+}
+
+impl {{ archetype.name.raw }}EntityComponents {
+    /// Spawn this entity into the given world.
+    #[inline]
+    #[allow(dead_code)]
+    pub fn spawn_into<W>(self, world: &mut W) -> EntityId
+    where
+        W: Spawn<{{ archetype.name.raw }}EntityComponents>
     {
         world.spawn(self)
     }
 }
 
 impl core::ops::Deref for {{ archetype.name.raw }}Entity {
-    type Target = {{ archetype.name.raw }}EntityData;
+    type Target = {{ archetype.name.raw }}EntityComponents;
 
     fn deref(&self) -> &Self::Target {
         &self.data

--- a/templates/world.rs.jinja2
+++ b/templates/world.rs.jinja2
@@ -340,10 +340,19 @@ impl AsMut<{{ system.name.type }}Data> for {{ world.name.type }}Systems {
 {%- for archetype in world.archetypes %}
 
 /// Spawns an entity into the world.
-impl<E, Q> Spawn<{{ archetype.name.raw}}EntityData> for {{ world.name.type }}<E, Q> {
+impl<E, Q> Spawn<{{ archetype.name.raw }}EntityData> for {{ world.name.type }}<E, Q> {
     /// Spawn a new entity into the world.
     #[inline]
-    fn spawn(&mut self, data: {{ archetype.name.raw}}EntityData) -> EntityId {
+    fn spawn(&mut self, data: {{ archetype.name.raw }}EntityData) -> EntityId {
+        self.spawn_{{ archetype.name.field}}(data)
+    }
+}
+
+/// Spawns an entity into the world.
+impl<E, Q> Spawn<{{ archetype.name.raw }}EntityComponents> for {{ world.name.type }}<E, Q> {
+    /// Spawn a new entity into the world.
+    #[inline]
+    fn spawn(&mut self, data: {{ archetype.name.raw }}EntityComponents) -> EntityId {
         self.spawn_{{ archetype.name.field}}(data)
     }
 }
@@ -453,10 +462,14 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
 
     /// Spawn a new `{{ archetype.name.raw }}` entity into the world given its [`{{ archetype.name.raw }}EntityData`].
     #[inline]
-    pub fn spawn_{{ archetype.name.field }}(
+    pub fn spawn_{{ archetype.name.field }}<Entity>(
         &mut self,
-        {{ archetype.name.field }}: {{ archetype.name.raw }}EntityData
-    ) -> EntityId {
+        {{ archetype.name.field }}: Entity
+    ) -> EntityId
+    where
+        Entity: Into<{{ archetype.name.raw }}EntityComponents>
+    {
+        let {{ archetype.name.field }} = {{ archetype.name.field }}.into();
         self.spawn_{{ archetype.name.field }}_with(
             {%- for component_name in archetype.components %}
             {{ archetype.name.field }}.{{component_name.field}},


### PR DESCRIPTION
This pull request introduces significant changes to the entity and archetype system, focusing on improving type safety, flexibility, and usability by introducing a new `EntityComponents` struct alongside the existing `EntityData` struct. The changes also include updates to world spawning functionality to support the new structure.

### Enhancements to Entity and Archetype Definitions:
* Introduced a new `{{ archetype.name.raw }}EntityComponents` struct to represent the components of an entity, distinct from the existing `{{ archetype.name.raw }}EntityData` struct. This separation enhances clarity and type safety. (`templates/archetypes.rs.jinja2`, [templates/archetypes.rs.jinja2L264-R301](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828L264-R301))
* Added a conversion implementation (`From<{{ archetype.name.raw }}EntityData> for {{ archetype.name.raw }}EntityComponents`) to enable seamless transitions between `EntityData` and `EntityComponents`. (`templates/archetypes.rs.jinja2`, [templates/archetypes.rs.jinja2L264-R301](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828L264-R301))

### Updates to Entity Functionality:
* Updated the `HasComponent` implementation to use `{{ archetype.name.raw }}EntityComponents` instead of `{{ archetype.name.raw }}EntityData`. (`templates/archetypes.rs.jinja2`, [templates/archetypes.rs.jinja2L472-R495](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828L472-R495))
* Added a `spawn_into` method for `{{ archetype.name.raw }}EntityComponents` to simplify spawning entities into the world. (`templates/archetypes.rs.jinja2`, [templates/archetypes.rs.jinja2R519-R532](diffhunk://#diff-802c892c20f5989f3b01c8ba36fd94036a193f088dd135fdf48c014220e52828R519-R532))

### Enhancements to World Spawning:
* Introduced a new `Spawn<{{ archetype.name.raw }}EntityComponents>` implementation to allow spawning entities using the new `EntityComponents` struct. (`templates/world.rs.jinja2`, [templates/world.rs.jinja2R350-R358](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbR350-R358))
* Updated the `spawn_{{ archetype.name.field }}` method to accept a generic `Entity` type that can be converted into `{{ archetype.name.raw }}EntityComponents`, improving flexibility. (`templates/world.rs.jinja2`, [templates/world.rs.jinja2L456-R472](diffhunk://#diff-d5bbff9e4d0704db47222ede8b9bcb11902034016e1587e8057639fd14f70ccbL456-R472))

### Miscellaneous Fixes:
* Removed an unnecessary `.into()` call in the `README.md` example for instantiating shaders, reflecting updates to the API. (`README.md`, [README.mdL334-R334](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L334-R334))