### PR TITLE
Iterate components regardless of archetype

### DIFF
--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -1697,6 +1697,7 @@ where
 
 /// An iterator over all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
 #[allow(dead_code)]
+// TODO: Simplify to ::core::slice::Iter<> if only one archetype has this component.
 pub type {{ component.name.raw }}ComponentIterator<'a> = ::sillyecs::FlattenSlices<'a, {{ component.name.type }}>;
 
 /// A trait for types allowing to iterate all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
@@ -1720,6 +1721,7 @@ impl<'a, E, Q> Iter{{ component.raw }}Components<'a> for {{ world.name.type }}<E
     /// {%- for archetype in world.archetypes %}{% for arch_comp in archetype.components %}{% if arch_comp.type == component.type %}
     /// - [`{{archetype.name.raw}}`]({{archetype.name.type}}){% endif %}{% endfor %}{% endfor %}
     fn iter_{{ component.fields }}(&'a self) -> Self::Iterator {
+        // TODO: Simplify to ::core::slice::Iter<> if only one archetype has this component.
         {{ component.raw }}ComponentIterator::new([
             {%- for archetype in world.archetypes %}
             {%- for arch_comp in archetype.components %}

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -1693,3 +1693,43 @@ where
     type UserCommand = U;
 }
 {%- endfor %}
+{%- for component in ecs.components %}
+
+/// An iterator over all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
+#[allow(dead_code)]
+pub type {{ component.name.raw }}ComponentIterator<'a> = ::sillyecs::FlattenSlices<'a, {{ component.name.type }}>;
+
+/// A trait for types allowing to iterate all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
+#[allow(dead_code)]
+pub trait Iter{{ component.name.raw }}Components<'a> {
+    type Iterator: core::iter::Iterator<Item = &'a {{ component.name.type }}>;
+
+    /// Iterates all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
+    fn iter_{{ component.name.fields }}(&'a self) -> Self::Iterator;
+}
+{%- endfor %}
+{%- for world in ecs.worlds %}
+{%- for component in world.components %}
+
+#[allow(dead_code)]
+impl<'a, E, Q> Iter{{ component.raw }}Components<'a> for {{ world.name.type }}<E, Q>
+{
+    type Iterator = {{ component.raw }}ComponentIterator<'a>;
+
+    /// Iterates over the [`{{ component.raw }}`]({{ component.type}}) component of the following archetypes, in that order:
+    /// {%- for archetype in world.archetypes %}{% for arch_comp in archetype.components %}{% if arch_comp.type == component.type %}
+    /// - [`{{archetype.name.raw}}`]({{archetype.name.type}}){% endif %}{% endfor %}{% endfor %}
+    fn iter_{{ component.fields }}(&'a self) -> Self::Iterator {
+        {{ component.raw }}ComponentIterator::new([
+            {%- for archetype in world.archetypes %}
+            {%- for arch_comp in archetype.components %}
+            {%- if arch_comp.type == component.type %}
+            &self.archetypes.collection.{{archetype.name.field}}.{{ arch_comp.fields }},
+            {%- endif %}
+            {%- endfor %}
+            {%- endfor %}
+        ])
+    }
+}
+{%- endfor %}
+{%- endfor %}

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -256,6 +256,7 @@ pub struct {{ world.name.type }}States {
     {%- endfor %}
 }
 
+#[allow(dead_code)]
 impl {{ world.name.type }}States {
     pub const fn new(
         {%- for state in world.states %}
@@ -1698,7 +1699,12 @@ where
 /// An iterator over all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
 #[allow(dead_code)]
 // TODO: Simplify to ::core::slice::Iter<> if only one archetype has this component.
-pub type {{ component.name.raw }}ComponentIterator<'a> = ::sillyecs::FlattenSlices<'a, {{ component.name.type }}>;
+pub type {{ component.name.raw }}ComponentIter<'a> = ::sillyecs::FlattenSlices<'a, {{ component.name.type }}>;
+
+/// A mutable iterator over all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
+#[allow(dead_code)]
+// TODO: Simplify to ::core::slice::IterMut<> if only one archetype has this component.
+pub type {{ component.name.raw }}ComponentIterMut<'a> = ::sillyecs::FlattenSlicesMut<'a, {{ component.name.type }}>;
 
 /// A trait for types allowing to iterate all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
 #[allow(dead_code)]
@@ -1708,6 +1714,15 @@ pub trait Iter{{ component.name.raw }}Components<'a> {
     /// Iterates all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
     fn iter_{{ component.name.fields }}(&'a self) -> Self::Iterator;
 }
+
+/// A trait for types allowing to iterate all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
+#[allow(dead_code)]
+pub trait IterMut{{ component.name.raw }}Components<'a> {
+    type IteratorMut: core::iter::Iterator<Item = &'a mut {{ component.name.type }}>;
+
+    /// Iterates all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
+    fn iter_{{ component.name.fields }}(&'a mut self) -> Self::IteratorMut;
+}
 {%- endfor %}
 {%- for world in ecs.worlds %}
 {%- for component in world.components %}
@@ -1715,18 +1730,40 @@ pub trait Iter{{ component.name.raw }}Components<'a> {
 #[allow(dead_code)]
 impl<'a, E, Q> Iter{{ component.raw }}Components<'a> for {{ world.name.type }}<E, Q>
 {
-    type Iterator = {{ component.raw }}ComponentIterator<'a>;
+    type Iterator = {{ component.raw }}ComponentIter<'a>;
 
     /// Iterates over the [`{{ component.raw }}`]({{ component.type}}) component of the following archetypes, in that order:
     /// {%- for archetype in world.archetypes %}{% for arch_comp in archetype.components %}{% if arch_comp.type == component.type %}
     /// - [`{{archetype.name.raw}}`]({{archetype.name.type}}){% endif %}{% endfor %}{% endfor %}
     fn iter_{{ component.fields }}(&'a self) -> Self::Iterator {
         // TODO: Simplify to ::core::slice::Iter<> if only one archetype has this component.
-        {{ component.raw }}ComponentIterator::new([
+        {{ component.raw }}ComponentIter::new([
             {%- for archetype in world.archetypes %}
             {%- for arch_comp in archetype.components %}
             {%- if arch_comp.type == component.type %}
             &self.archetypes.collection.{{archetype.name.field}}.{{ arch_comp.fields }},
+            {%- endif %}
+            {%- endfor %}
+            {%- endfor %}
+        ])
+    }
+}
+
+#[allow(dead_code)]
+impl<'a, E, Q> IterMut{{ component.raw }}Components<'a> for {{ world.name.type }}<E, Q>
+{
+    type IteratorMut = {{ component.raw }}ComponentIterMut<'a>;
+
+    /// Mutably iterates over the [`{{ component.raw }}`]({{ component.type}}) component of the following archetypes, in that order:
+    /// {%- for archetype in world.archetypes %}{% for arch_comp in archetype.components %}{% if arch_comp.type == component.type %}
+    /// - [`{{archetype.name.raw}}`]({{archetype.name.type}}){% endif %}{% endfor %}{% endfor %}
+    fn iter_{{ component.fields }}(&'a mut self) -> Self::IteratorMut {
+        // TODO: Simplify to ::core::slice::Iter<> if only one archetype has this component.
+        {{ component.raw }}ComponentIterMut::new([
+            {%- for archetype in world.archetypes %}
+            {%- for arch_comp in archetype.components %}
+            {%- if arch_comp.type == component.type %}
+            &mut self.archetypes.collection.{{archetype.name.field}}.{{ arch_comp.fields }},
             {%- endif %}
             {%- endfor %}
             {%- endfor %}

--- a/crates/sillyecs/src/flatten_slices_mut.rs
+++ b/crates/sillyecs/src/flatten_slices_mut.rs
@@ -1,0 +1,121 @@
+use std::iter::FusedIterator;
+
+/// A mutable iterator over a slice of slices.
+///
+/// Presents the inner slices as one contiguous set of mutable references.
+pub struct FlattenSlicesMut<'a, T> {
+    slices: Box<[&'a mut [T]]>,
+    front: (usize, usize),
+    back: (usize, usize),
+}
+
+impl<'a, T> FlattenSlicesMut<'a, T> {
+    pub fn new<const N: usize>(slices: [&'a mut [T]; N]) -> Self {
+        let slices = Box::new(slices);
+        let mut back = (0, 0);
+        for (i, s) in slices.iter().enumerate().rev() {
+            if !s.is_empty() {
+                back = (i, s.len());
+                break;
+            }
+        }
+
+        Self {
+            slices,
+            front: (0, 0),
+            back,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.front = (0, 0);
+        self.back = Self::compute_back(&self.slices);
+    }
+
+    fn compute_back(slices: &[&'a mut [T]]) -> (usize, usize) {
+        for (i, s) in slices.iter().enumerate().rev() {
+            if !s.is_empty() {
+                return (i, s.len());
+            }
+        }
+        (0, 0)
+    }
+}
+
+impl<'a, T> Iterator for FlattenSlicesMut<'a, T> {
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.front < self.back {
+            let (slice_idx, elem_idx) = self.front;
+
+            if let Some(slice) = self.slices.get_mut(slice_idx) {
+                if elem_idx < slice.len() {
+                    let item = unsafe {
+                        // Safety: we ensure unique access by advancing the front position immediately
+                        let item = &mut *(&mut slice[elem_idx] as *mut T);
+                        self.front.1 += 1;
+                        if self.front.1 >= slice.len() {
+                            self.front.0 += 1;
+                            self.front.1 = 0;
+                        }
+                        item
+                    };
+                    return Some(item);
+                } else {
+                    self.front.0 += 1;
+                    self.front.1 = 0;
+                }
+            } else {
+                break;
+            }
+        }
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut count = 0;
+        for i in self.front.0..=self.back.0 {
+            let slice = &self.slices[i];
+            let start = if i == self.front.0 { self.front.1 } else { 0 };
+            let end = if i == self.back.0 {
+                self.back.1
+            } else {
+                slice.len()
+            };
+            if end > start {
+                count += end - start;
+            }
+        }
+        (count, Some(count))
+    }
+}
+
+impl<'a, T> ExactSizeIterator for FlattenSlicesMut<'a, T> {}
+impl<'a, T> FusedIterator for FlattenSlicesMut<'a, T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_forward() {
+        let s1 = &mut [1, 2][..];
+        let s2 = &mut [3][..];
+        let s3 = &mut [][..];
+        let s4 = &mut [4, 5, 6][..];
+
+        let mut iter = FlattenSlicesMut::new([s1, s2, s3, s4]);
+
+        let size = iter.len();
+        assert_eq!(size, 6);
+        assert_eq!(iter.size_hint(), (6, Some(6)));
+
+        // Mutate an entry
+        let first = iter.next().unwrap();
+        *first = 10;
+        iter.reset();
+
+        assert_eq!(iter.map(|a| *a).collect::<Vec<i32>>(), &[10, 2, 3, 4, 5, 6]);
+    }
+}

--- a/crates/sillyecs/src/lib.rs
+++ b/crates/sillyecs/src/lib.rs
@@ -1,4 +1,6 @@
 //! # Utility functions for `sillyecs`.
 
 mod flatten_slices;
+mod flatten_slices_mut;
 pub use flatten_slices::FlattenSlices;
+pub use flatten_slices_mut::FlattenSlicesMut;


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `sillyecs` library, focusing on improving iteration capabilities for ECS components and slices. Key changes include adding mutable iteration support, refining existing iterators, and introducing new traits and types for component iteration. Below is a categorized summary of the most important changes:

### Component Iteration Enhancements
* Added new iterator types (`{{ component.name.raw }}ComponentIter` and `{{ component.name.raw }}ComponentIterMut`) and corresponding traits (`Iter{{ component.name.raw }}Components` and `IterMut{{ component.name.raw }}Components`) to enable iteration over ECS components across archetypes, both immutably and mutably. These types and traits were added to the `world.rs.jinja2` template.

### Slice Iteration Improvements
* Introduced `FlattenSlicesMut`, a mutable iterator over slices of slices, with support for `Iterator`, `ExactSizeIterator`, and `FusedIterator` traits. This includes a `reset` method for reinitializing the iterator and a test suite to validate its functionality.
* Refined the `FlattenSlices` iterator by fixing the `next` method to handle edge cases and ensuring it implements `ExactSizeIterator` and `FusedIterator`. Removed the `DoubleEndedIterator` implementation and its associated reverse iteration test. [[1]](diffhunk://#diff-5e77d0068f548174470562a75df7035b4c15a585dd900356217f2d0ea18fc71bL46-R57) [[2]](diffhunk://#diff-5e77d0068f548174470562a75df7035b4c15a585dd900356217f2d0ea18fc71bL87-R94) [[3]](diffhunk://#diff-5e77d0068f548174470562a75df7035b4c15a585dd900356217f2d0ea18fc71bL131-L144)

### Library Structure Updates
* Added the `flatten_slices_mut` module and exposed `FlattenSlicesMut` in the library's public API.

### Code Quality Improvements
* Added `#[allow(dead_code)]` attributes to suppress warnings for unused code in generated ECS templates, ensuring cleaner builds. [[1]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0R259) [[2]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0R1697-R1774)