### PR TITLE
Move entity ID to support library

### DIFF
--- a/crates/sillyecs-build/templates/archetypes.rs.jinja2
+++ b/crates/sillyecs-build/templates/archetypes.rs.jinja2
@@ -1,58 +1,3 @@
-/// The ID of an entity.
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
-pub struct EntityId(core::num::NonZeroU64);
-
-#[allow(dead_code)]
-impl EntityId {
-    /// Returns a new, unique entity ID.
-    ///
-    /// Uniqueness is guaranteed by using a monotonically increasing `AtomicU64` counter
-    /// for generating IDs, starting from 1.
-    ///
-    /// # Implementation
-    /// This function uses a thread-safe counter with sequential consistency ordering
-    /// to ensure unique IDs even under concurrent access.
-    pub fn new() -> Self {
-        static ENTITY_IDS: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(1);
-        let id = ENTITY_IDS.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
-        EntityId(core::num::NonZeroU64::new(id).expect("ID was zero"))
-    }
-
-    /// Returns this ID as a [`NonZeroU64`](core::num::NonZeroU64) value.
-    pub const fn as_nonzero_u64(&self) -> core::num::NonZeroU64 {
-        self.0
-    }
-
-    /// Returns this ID as a `u64` value.
-    pub const fn as_u64(&self) -> u64 {
-        self.0.get()
-    }
-}
-
-impl core::hash::Hash for EntityId {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state);
-    }
-}
-
-impl From<EntityId> for core::num::NonZeroU64 {
-    fn from(value: EntityId) -> core::num::NonZeroU64 {
-        value.as_nonzero_u64()
-    }
-}
-
-impl From<EntityId> for u64 {
-    fn from(value: EntityId) -> u64 {
-        value.as_u64()
-    }
-}
-
-impl core::fmt::Display for EntityId {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-        core::fmt::Display::fmt(&self.0.get(), f)
-    }
-}
-
 /// The ID of an [`Archetype`].
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 #[repr(u32)]
@@ -135,7 +80,7 @@ pub struct EntityArchetypeRef {
 #[allow(dead_code)]
 pub trait Spawn<E> {
     /// Spawn a new entity into the world.
-    fn spawn(&mut self, data: E) -> EntityId;
+    fn spawn(&mut self, data: E) -> ::sillyecs::EntityId;
 }
 
 /// Marker trait for archetypes.
@@ -237,7 +182,7 @@ impl ArchetypeEntityData {
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct EntityWithIdAndData<Data: EntityData> {
-    pub id: EntityId,
+    pub id: ::sillyecs::EntityId,
     pub data: Data,
 }
 
@@ -254,7 +199,7 @@ pub trait EntityData {
 {%- endif %}
 #[derive(Debug, Default, Clone)]
 pub struct {{ archetype.name.type }} {
-    pub entities: Vec<EntityId>,
+    pub entities: Vec<::sillyecs::EntityId>,
     {%- for component_name in archetype.components %}
     pub {{ component_name.fields }}: Vec<{{ component_name.type }}>,
     {%- endfor %}
@@ -303,7 +248,7 @@ impl EntityData for {{ archetype.name.raw }}EntityComponents {
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct {{ archetype.name.raw }}EntityRef<'archetype> {
-    pub entity_id: EntityId,
+    pub entity_id: ::sillyecs::EntityId,
     {%- for component_name in archetype.components %}
     pub {{ component_name.field }}: &'archetype {{ component_name.type }},
     {%- endfor %}
@@ -313,7 +258,7 @@ pub struct {{ archetype.name.raw }}EntityRef<'archetype> {
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct {{ archetype.name.raw }}EntityMut<'archetype> {
-    pub entity_id: EntityId,
+    pub entity_id: ::sillyecs::EntityId,
     {%- for component_name in archetype.components %}
     pub {{ component_name.field }}: &'archetype mut {{ component_name.type }},
     {%- endfor %}
@@ -508,7 +453,7 @@ impl {{ archetype.name.raw }}EntityData {
     /// Spawn this entity into the given world.
     #[inline]
     #[allow(dead_code)]
-    pub fn spawn_into<W>(self, world: &mut W) -> EntityId
+    pub fn spawn_into<W>(self, world: &mut W) -> ::sillyecs::EntityId
     where
         W: Spawn<{{ archetype.name.raw }}EntityData>
     {
@@ -520,7 +465,7 @@ impl {{ archetype.name.raw }}EntityComponents {
     /// Spawn this entity into the given world.
     #[inline]
     #[allow(dead_code)]
-    pub fn spawn_into<W>(self, world: &mut W) -> EntityId
+    pub fn spawn_into<W>(self, world: &mut W) -> ::sillyecs::EntityId
     where
         W: Spawn<{{ archetype.name.raw }}EntityComponents>
     {
@@ -584,7 +529,7 @@ impl {{ archetype.name.type }} {
         {{component_name.field}}: {{ component_name.type }},
         {%- endfor %}
         mut world_registry: R
-    ) -> EntityId
+    ) -> ::sillyecs::EntityId
     where
         R: WorldEntityRegistry
     {
@@ -592,7 +537,7 @@ impl {{ archetype.name.type }} {
         self.{{ component_name.fields }}.push({{component_name.field}});
         {%- endfor %}
 
-        let entity_id = EntityId::new();
+        let entity_id = ::sillyecs::EntityId::new();
 
         let entity_index = self.entities.len();
         self.entities.push(entity_id);
@@ -609,7 +554,7 @@ impl {{ archetype.name.type }} {
     ///
     /// Returns the ID of the entity that was moved into the hole, or [`None`] if the archetype is now empty.
     #[doc(hidden)]
-    pub fn drop_at_index(&mut self, index: usize) -> Result<Option<EntityId>, usize> {
+    pub fn drop_at_index(&mut self, index: usize) -> Result<Option<::sillyecs::EntityId>, usize> {
         if index > self.entities.len() {
             return Err(index);
         }
@@ -701,7 +646,7 @@ pub trait GetEntityRef {
 {%- for archetype in ecs.archetypes %}
 
 impl core::ops::Index<usize> for {{ archetype.name.type }} {
-    type Output = EntityId;
+    type Output = ::sillyecs::EntityId;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.entities[index]
@@ -712,14 +657,14 @@ impl core::ops::Index<usize> for {{ archetype.name.type }} {
 #[allow(dead_code)]
 pub trait FrontloadEntities:
     Archetype
-    + core::ops::Index<usize, Output = EntityId>
+    + core::ops::Index<usize, Output = ::sillyecs::EntityId>
 {
     /// Frontloads entities provided by their IDs (e.g., from quadtree results).
     /// Returns the count of frontloaded entities.
     fn frontload(
         &mut self,
-        entity_lookup: &mut EntityLocationMap<EntityId, EntityArchetypeRef>,
-        entities_to_frontload: &[EntityId],
+        entity_lookup: &mut EntityLocationMap<::sillyecs::EntityId, EntityArchetypeRef>,
+        entities_to_frontload: &[::sillyecs::EntityId],
         previous_frontload_pivot: Option<usize>
     ) -> usize {
         // Collect and filter valid indices
@@ -745,7 +690,7 @@ pub trait FrontloadEntities:
     /// Returns the count of frontloaded entities.
     fn frontload_by_indices_sorted<I>(
         &mut self,
-        entity_lookup: &mut EntityLocationMap<EntityId, EntityArchetypeRef>,
+        entity_lookup: &mut EntityLocationMap<::sillyecs::EntityId, EntityArchetypeRef>,
         indices_to_frontload: I,
         previous_frontload_pivot: Option<usize>
     ) -> usize
@@ -805,13 +750,13 @@ pub trait FrontloadEntitiesScan:
     Archetype
     + FrontloadEntities
     + GetEntityRef
-    + core::ops::Index<usize, Output = EntityId>
+    + core::ops::Index<usize, Output = ::sillyecs::EntityId>
 {
     /// Frontloads entities satisfying `should_frontload`.
     /// Returns the number of entities frontloaded.
     fn frontload_scan<F>(
         &mut self,
-        entity_lookup: &mut EntityLocationMap<EntityId, EntityArchetypeRef>,
+        entity_lookup: &mut EntityLocationMap<::sillyecs::EntityId, EntityArchetypeRef>,
         mut should_frontload: F,
     ) -> usize
     where

--- a/crates/sillyecs-build/templates/systems.rs.jinja2
+++ b/crates/sillyecs-build/templates/systems.rs.jinja2
@@ -448,7 +448,7 @@ pub trait Apply{{ system.name.type }}: System {
             {%- endif %}
         {%- endfor %}
         {%- if system.needs_entities %}
-        entities: &[EntityId],
+        entities: &[::sillyecs::EntityId],
         {%- endif %}
         {%- for input in system.inputs %}
         {{ input.fields }}: &[{{ input.type }}],
@@ -497,7 +497,7 @@ pub trait Apply{{ system.name.type }}: System {
             {%- endif %}
         {%- endfor %}
         {%- if system.needs_entities %}
-        entities: &[EntityId],
+        entities: &[::sillyecs::EntityId],
         {%- endif %}
         {%- for input in system.inputs %}
         {{ input.fields }}: &[{{ input.type }}],
@@ -542,7 +542,7 @@ pub trait Apply{{ system.name.type }}: System {
             {%- endif %}
         {%- endfor %}
         {%- if system.needs_entities %}
-        entity: EntityId,
+        entity: ::sillyecs::EntityId,
         {%- endif %}
         {%- for input in system.inputs %}
         {{ input.field }}: &{{ input.type }},
@@ -584,7 +584,7 @@ pub trait Apply{{ system.name.type }}: System {
             {%- endif %}
         {%- endfor %}
         {%- if system.needs_entities %}
-        entities: &[EntityId],
+        entities: &[::sillyecs::EntityId],
         {%- endif %}
         {%- for input in system.inputs %}
         {{ input.fields }}: &[{{ input.type }}],
@@ -649,7 +649,7 @@ impl {{ system.name.type }} {
             {%- endif %}
         {%- endfor %}
         {%- if system.needs_entities %}
-        entity: EntityId,
+        entity: ::sillyecs::EntityId,
         {%- endif %}
         {%- for input in system.inputs %}
         {{ input.field }}: &{{ input.type }},
@@ -718,7 +718,7 @@ impl {{ system.name.type }} {
             {%- endif %}
         {%- endfor %}
         {%- if system.needs_entities %}
-        entities: &[EntityId],
+        entities: &[::sillyecs::EntityId],
         {%- endif %}
         {%- for input in system.inputs %}
         {{ input.fields }}: &[{{ input.type }}],
@@ -801,7 +801,7 @@ pub trait {{ system.name.raw }}ComponentLookup {
     {%- for component in system.lookup %}
     /// Gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
     #[allow(dead_code, unused)]
-    fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}>;
+    fn get_{{component.field}}_component(&self, entity_id: ::sillyecs::EntityId) -> Option<&{{component.type}}>;
     {%- endfor %}
 }
 
@@ -813,7 +813,7 @@ where
     /// Gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
     #[allow(dead_code, unused)]
     #[inline]
-    fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}> {
+    fn get_{{component.field}}_component(&self, entity_id: ::sillyecs::EntityId) -> Option<&{{component.type}}> {
         T::get_{{component.field}}_component(self, entity_id)
     }
     {%- endfor %}

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -56,7 +56,7 @@ pub enum WorldCommand<UserCommand> {
     /// Due to the reusability of systems, not all commands are valid in all worlds.
     SpawnEntity(ArchetypeEntityData),
     /// Despawn an entity.
-    DespawnEntity(EntityId),
+    DespawnEntity(::sillyecs::EntityId),
     /// A user-specific command.
     User(UserCommand)
 }
@@ -283,7 +283,7 @@ struct {{ world.name.type }}Archetypes {
     // Example:
     //      type EntityLocationMap<K, V> = fxhash::FxHashMap<K, V>;
     //
-    entity_locations: EntityLocationMap<EntityId, EntityArchetypeRef>,
+    entity_locations: EntityLocationMap<::sillyecs::EntityId, EntityArchetypeRef>,
 
     pub collection: {{ world.name.type }}ArchetypeCollection
 }
@@ -344,7 +344,7 @@ impl AsMut<{{ system.name.type }}Data> for {{ world.name.type }}Systems {
 impl<E, Q> Spawn<{{ archetype.name.raw }}EntityData> for {{ world.name.type }}<E, Q> {
     /// Spawn a new entity into the world.
     #[inline]
-    fn spawn(&mut self, data: {{ archetype.name.raw }}EntityData) -> EntityId {
+    fn spawn(&mut self, data: {{ archetype.name.raw }}EntityData) -> ::sillyecs::EntityId {
         self.spawn_{{ archetype.name.field}}(data)
     }
 }
@@ -353,7 +353,7 @@ impl<E, Q> Spawn<{{ archetype.name.raw }}EntityData> for {{ world.name.type }}<E
 impl<E, Q> Spawn<{{ archetype.name.raw }}EntityComponents> for {{ world.name.type }}<E, Q> {
     /// Spawn a new entity into the world.
     #[inline]
-    fn spawn(&mut self, data: {{ archetype.name.raw }}EntityComponents) -> EntityId {
+    fn spawn(&mut self, data: {{ archetype.name.raw }}EntityComponents) -> ::sillyecs::EntityId {
         self.spawn_{{ archetype.name.field}}(data)
     }
 }
@@ -362,7 +362,7 @@ impl<E, Q> Spawn<{{ archetype.name.raw }}EntityComponents> for {{ world.name.typ
 /// Helper trait to prevent accidental abuse of the Archetype's spawning function.
 pub trait WorldEntityRegistry {
     /// Registers an entity with the world.
-    fn register(&mut self, id: EntityId, archetype: EntityArchetypeRef) -> EntityId;
+    fn register(&mut self, id: ::sillyecs::EntityId, archetype: EntityArchetypeRef) -> ::sillyecs::EntityId;
 }
 
 #[allow(dead_code)]
@@ -445,8 +445,8 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         self.archetypes.entity_locations.is_empty()
     }
 
-    /// De-spawns an entity given by its [`EntityId`]. Returns an error if the entity was unknown in this world.
-    pub fn despawn_by_id(&mut self, id: EntityId) -> Result<(), DespawnError> {
+    /// De-spawns an entity given by its [`::sillyecs::EntityId`]. Returns an error if the entity was unknown in this world.
+    pub fn despawn_by_id(&mut self, id: ::sillyecs::EntityId) -> Result<(), DespawnError> {
         self.handle_despawn_command(id)
     }
     {%- for phase in ecs.phases %}
@@ -466,7 +466,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     pub fn spawn_{{ archetype.name.field }}<Entity>(
         &mut self,
         {{ archetype.name.field }}: Entity
-    ) -> EntityId
+    ) -> ::sillyecs::EntityId
     where
         Entity: Into<{{ archetype.name.raw }}EntityComponents>
     {
@@ -484,12 +484,12 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         {%- for component_name in archetype.components %}
         {{component_name.field}}: {{ component_name.type }},
         {%- endfor %}
-    ) -> EntityId {
-        struct Registry<'a>(&'a mut EntityLocationMap<EntityId, EntityArchetypeRef>);
+    ) -> ::sillyecs::EntityId {
+        struct Registry<'a>(&'a mut EntityLocationMap<::sillyecs::EntityId, EntityArchetypeRef>);
 
         impl WorldEntityRegistry for Registry<'_> {
             #[inline(always)]
-            fn register(&mut self, id: EntityId, archetype: EntityArchetypeRef) -> EntityId {
+            fn register(&mut self, id: ::sillyecs::EntityId, archetype: EntityArchetypeRef) -> ::sillyecs::EntityId {
                 self.0.insert(id, archetype);
                 id
             }
@@ -1286,7 +1286,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         }
     }
 
-    fn handle_despawn_command(&mut self, id: EntityId) -> Result<(), DespawnError> {
+    fn handle_despawn_command(&mut self, id: ::sillyecs::EntityId) -> Result<(), DespawnError> {
          if let Some(loc) = self.archetypes.entity_locations.remove(&id) {
             let result = match loc.archetype {
                 {%- for archetype in world.archetypes %}
@@ -1354,7 +1354,7 @@ impl Default for DeltaTimers {
 
 #[derive(Debug)]
 pub enum DespawnError {
-    EntityNotFound(EntityId),
+    EntityNotFound(::sillyecs::EntityId),
     InvalidIndexInArchetype(usize, ArchetypeId)
 }
 
@@ -1409,7 +1409,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     #[allow(dead_code)]
     pub fn frontload_{{ archetype.name.fields }}(
         &mut self,
-        entities_to_frontload: &[EntityId],
+        entities_to_frontload: &[::sillyecs::EntityId],
         previous_frontload_pivot: Option<usize>
     ) -> usize {
         self.archetypes
@@ -1477,7 +1477,7 @@ pub trait ComponentAccess {
     /// Gets the [`{{component.name.raw}}`]({{component.name.type}}) component of the specified entity.
     #[allow(dead_code, unused)]
     #[inline]
-    fn get_{{component.name.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.name.type}}> {
+    fn get_{{component.name.field}}_component(&self, entity_id: ::sillyecs::EntityId) -> Option<&{{component.name.type}}> {
         None
     }
     {%- endfor %}
@@ -1489,7 +1489,7 @@ pub trait ComponentAccessMut: ComponentAccess {
     /// Mutably gets the [`{{component.name.raw}}`]({{component.name.type}}) component of the specified entity.
     #[allow(dead_code, unused)]
     #[inline]
-    fn get_{{component.name.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.name.type}}> {
+    fn get_{{component.name.field}}_component_mut(&mut self, entity_id: ::sillyecs::EntityId) -> Option<&mut {{component.name.type}}> {
         None
     }
     {%- endfor %}
@@ -1503,7 +1503,7 @@ pub trait EntityAccess {
     #[inline]
     fn get_{{ archetype.name.field }}_entity(
         &self,
-        entity_id: EntityId
+        entity_id: ::sillyecs::EntityId
     ) -> Option<{{ archetype.name.raw }}EntityRef>
     {
         None
@@ -1519,7 +1519,7 @@ pub trait EntityAccessMut: EntityAccess {
     #[inline]
     fn get_{{ archetype.name.field }}_entity_mut(
         &mut self,
-        entity_id: EntityId
+        entity_id: ::sillyecs::EntityId
     ) -> Option<{{ archetype.name.raw }}EntityMut>
     {
         None
@@ -1537,7 +1537,7 @@ impl<E, Q> EntityAccess for {{ world.name.type }}<E, Q> {
     #[inline]
     fn get_{{ archetype.name.field }}_entity(
         &self,
-        entity_id: EntityId
+        entity_id: ::sillyecs::EntityId
     ) -> Option<{{ archetype.name.raw }}EntityRef>
     {
         EntityAccess::get_{{ archetype.name.field }}_entity(&self.archetypes, entity_id)
@@ -1556,7 +1556,7 @@ impl<E, Q> EntityAccessMut for {{ world.name.type }}<E, Q> {
     #[inline]
     fn get_{{ archetype.name.field }}_entity_mut(
         &mut self,
-        entity_id: EntityId
+        entity_id: ::sillyecs::EntityId
     ) -> Option<{{ archetype.name.raw }}EntityMut>
     {
         EntityAccessMut::get_{{ archetype.name.field }}_entity_mut(&mut self.archetypes, entity_id)
@@ -1573,7 +1573,7 @@ impl<E, Q> ComponentAccess for {{ world.name.type }}<E, Q> {
     /// Gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
     #[allow(dead_code, unused)]
     #[inline]
-    fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}> {
+    fn get_{{component.field}}_component(&self, entity_id: ::sillyecs::EntityId) -> Option<&{{component.type}}> {
         ComponentAccess::get_{{component.field}}_component(&self.archetypes, entity_id)
     }
     {%- endfor %}
@@ -1588,7 +1588,7 @@ impl<E, Q> ComponentAccessMut for {{ world.name.type }}<E, Q> {
     /// Mutably gets the [`{{component.raw}}`]({{component.type}}) component of the specified entity.
     #[allow(dead_code, unused)]
     #[inline]
-    fn get_{{component.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.type}}> {
+    fn get_{{component.field}}_component_mut(&mut self, entity_id: ::sillyecs::EntityId) -> Option<&mut {{component.type}}> {
         ComponentAccessMut::get_{{component.field}}_component_mut(&mut self.archetypes, entity_id)
     }
     {%- endfor %}
@@ -1604,7 +1604,7 @@ impl EntityAccess for {{ world.name.type }}Archetypes {
     #[allow(dead_code, unused)]
     fn get_{{ archetype.name.field }}_entity(
         &self,
-        entity_id: EntityId
+        entity_id: ::sillyecs::EntityId
     ) -> Option<{{ archetype.name.raw }}EntityRef>
     {
         let ear = self.entity_locations.get(&entity_id)?.clone();
@@ -1628,7 +1628,7 @@ impl EntityAccessMut for {{ world.name.type }}Archetypes {
     #[allow(dead_code, unused)]
     fn get_{{ archetype.name.field }}_entity_mut(
         &mut self,
-        entity_id: EntityId
+        entity_id: ::sillyecs::EntityId
     ) -> Option<{{ archetype.name.raw }}EntityMut>
     {
         let ear = self.entity_locations.get(&entity_id)?.clone();
@@ -1650,7 +1650,7 @@ impl ComponentAccess for {{ world.name.type }}Archetypes {
 
     /// Gets the `{{component.raw}}` component of the specified entity.
     #[allow(dead_code)]
-    fn get_{{component.field}}_component(&self, entity_id: EntityId) -> Option<&{{component.type}}> {
+    fn get_{{component.field}}_component(&self, entity_id: ::sillyecs::EntityId) -> Option<&{{component.type}}> {
         let ear = self.entity_locations.get(&entity_id)?.clone();
         match ear.archetype {
             {%- for archetype in archetypes %}
@@ -1671,7 +1671,7 @@ impl ComponentAccessMut for {{ world.name.type }}Archetypes {
 
     /// Mutably gets the `{{component.raw}}` component of the specified entity.
     #[allow(dead_code)]
-    fn get_{{component.field}}_component_mut(&mut self, entity_id: EntityId) -> Option<&mut {{component.type}}> {
+    fn get_{{component.field}}_component_mut(&mut self, entity_id: ::sillyecs::EntityId) -> Option<&mut {{component.type}}> {
         let ear = self.entity_locations.get(&entity_id)?.clone();
         match ear.archetype {
             {%- for archetype in archetypes %}

--- a/crates/sillyecs/src/entity_id.rs
+++ b/crates/sillyecs/src/entity_id.rs
@@ -1,0 +1,54 @@
+/// The ID of an entity.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct EntityId(core::num::NonZeroU64);
+
+#[allow(dead_code)]
+impl EntityId {
+    /// Returns a new, unique entity ID.
+    ///
+    /// Uniqueness is guaranteed by using a monotonically increasing `AtomicU64` counter
+    /// for generating IDs, starting from 1.
+    ///
+    /// # Implementation
+    /// This function uses a thread-safe counter with sequential consistency ordering
+    /// to ensure unique IDs even under concurrent access.
+    pub fn new() -> Self {
+        static ENTITY_IDS: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(1);
+        let id = ENTITY_IDS.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
+        EntityId(core::num::NonZeroU64::new(id).expect("ID was zero"))
+    }
+
+    /// Returns this ID as a [`NonZeroU64`](core::num::NonZeroU64) value.
+    pub const fn as_nonzero_u64(&self) -> core::num::NonZeroU64 {
+        self.0
+    }
+
+    /// Returns this ID as a `u64` value.
+    pub const fn as_u64(&self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl core::hash::Hash for EntityId {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl From<EntityId> for core::num::NonZeroU64 {
+    fn from(value: EntityId) -> core::num::NonZeroU64 {
+        value.as_nonzero_u64()
+    }
+}
+
+impl From<EntityId> for u64 {
+    fn from(value: EntityId) -> u64 {
+        value.as_u64()
+    }
+}
+
+impl core::fmt::Display for EntityId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        core::fmt::Display::fmt(&self.0.get(), f)
+    }
+}

--- a/crates/sillyecs/src/lib.rs
+++ b/crates/sillyecs/src/lib.rs
@@ -1,6 +1,10 @@
 //! # Utility functions for `sillyecs`.
 
+mod archetypes;
+mod entity_id;
 mod flatten_slices;
 mod flatten_slices_mut;
+
+pub use entity_id::EntityId;
 pub use flatten_slices::FlattenSlices;
 pub use flatten_slices_mut::FlattenSlicesMut;


### PR DESCRIPTION
This pull request refactors the `EntityId` type to use a fully qualified path (`::sillyecs::EntityId`) throughout the codebase, enabling better modularity and compatibility with external crates. The changes primarily involve replacing the previous `EntityId` definition with the new path and updating all references to it across various files.

### Removal of `EntityId` definition:
* The `EntityId` struct and its associated methods, traits, and implementations were removed from `archetypes.rs.jinja2`. This includes the custom `new`, `as_nonzero_u64`, and `as_u64` methods, as well as conversions and formatting implementations.

### Updates to `archetypes.rs.jinja2`:
* Refactored all occurrences of `EntityId` to `::sillyecs::EntityId` in methods, structs, and traits, such as `Spawn`, `EntityWithIdAndData`, and `FrontloadEntities`. [[1]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL138-R83) [[2]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL240-R185) [[3]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL257-R202) [[4]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL306-R251) [[5]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL316-R261) [[6]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL511-R456) [[7]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL523-R468) [[8]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL587-R540) [[9]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL612-R557) [[10]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL704-R649) [[11]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL715-R667) [[12]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL748-R693) [[13]](diffhunk://#diff-6e6f3b9bf19fb30d07a857d2c5fc4c354d9a84f93bf8b6733f5868c42c5071bdL808-R759)

### Updates to `systems.rs.jinja2`:
* Replaced `EntityId` with `::sillyecs::EntityId` in system traits and methods, such as `Apply{{ system.name.type }}` and `{{ system.name.raw }}ComponentLookup`. [[1]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L451-R451) [[2]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L500-R500) [[3]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L545-R545) [[4]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L587-R587) [[5]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L652-R652) [[6]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L721-R721) [[7]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L804-R804) [[8]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L816-R816)

### Updates to `world.rs.jinja2`:
* Refactored the `WorldCommand` enum, archetype entity locations, and world methods to use `::sillyecs::EntityId`. This includes the `despawn_by_id` method, spawn functions, and the `WorldEntityRegistry` trait. [[1]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L59-R59) [[2]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L286-R286) [[3]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L347-R347) [[4]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L356-R356) [[5]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L365-R365) [[6]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L448-R449) [[7]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L469-R469) [[8]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L487-R492)

These changes ensure consistency in the use of `EntityId` across the codebase and improve the maintainability of the project.