### PR TITLE
Move WorldId to support library

### DIFF
--- a/crates/sillyecs/src/lib.rs
+++ b/crates/sillyecs/src/lib.rs
@@ -4,7 +4,9 @@ mod archetypes;
 mod entity_id;
 mod flatten_slices;
 mod flatten_slices_mut;
+mod world_id;
 
 pub use entity_id::EntityId;
 pub use flatten_slices::FlattenSlices;
 pub use flatten_slices_mut::FlattenSlicesMut;
+pub use world_id::WorldId;

--- a/crates/sillyecs/src/world_id.rs
+++ b/crates/sillyecs/src/world_id.rs
@@ -1,13 +1,13 @@
-use core::num::NonZeroU64;
-use core::sync::atomic::AtomicU64;
+pub use core::num::NonZeroU64;
+pub use core::sync::atomic::AtomicU64;
 
-/// The ID of an entity.
+/// The ID of a world.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
-pub struct EntityId(NonZeroU64);
+pub struct WorldId(NonZeroU64);
 
 #[allow(dead_code)]
-impl EntityId {
-    /// Returns a new, unique entity ID.
+impl WorldId {
+    /// Returns a new, unique world ID.
     ///
     /// Uniqueness is guaranteed by using a monotonically increasing `AtomicU64` counter
     /// for generating IDs, starting from 1.
@@ -16,9 +16,16 @@ impl EntityId {
     /// This function uses a thread-safe counter with sequential consistency ordering
     /// to ensure unique IDs even under concurrent access.
     pub fn new() -> Self {
-        static ENTITY_IDS: AtomicU64 = AtomicU64::new(1);
-        let id = ENTITY_IDS.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
-        EntityId(NonZeroU64::new(id).expect("ID was zero"))
+        static WORLD_IDS: AtomicU64 = AtomicU64::new(1);
+        let id = WORLD_IDS.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
+        WorldId(core::num::NonZeroU64::new(id).expect("ID was zero"))
+    }
+
+    /// Constructs a new [`WorldId`] from a known [`NonZeroU64`].
+    /// Used internally by the engine to generate valid IDs.
+    #[doc(hidden)]
+    pub const fn new_from(id: NonZeroU64) -> Self {
+        WorldId(id)
     }
 
     /// Returns this ID as a [`NonZeroU64`](NonZeroU64) value.
@@ -32,26 +39,20 @@ impl EntityId {
     }
 }
 
-impl core::hash::Hash for EntityId {
+impl core::hash::Hash for WorldId {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }
 }
 
-impl From<EntityId> for NonZeroU64 {
-    fn from(value: EntityId) -> NonZeroU64 {
+impl From<WorldId> for core::num::NonZeroU64 {
+    fn from(value: WorldId) -> core::num::NonZeroU64 {
         value.as_nonzero_u64()
     }
 }
 
-impl From<EntityId> for u64 {
-    fn from(value: EntityId) -> u64 {
+impl From<WorldId> for u64 {
+    fn from(value: WorldId) -> u64 {
         value.as_u64()
-    }
-}
-
-impl core::fmt::Display for EntityId {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-        core::fmt::Display::fmt(&self.0.get(), f)
     }
 }


### PR DESCRIPTION
This pull request refactors the `EntityId` implementation for improved readability and consistency and introduces a new `WorldId` type for managing unique world identifiers. Key changes include the simplification of imports, the addition of the `WorldId` module, and enhancements to the `EntityId` structure.

### Refactoring and simplification:

* Simplified import statements in `EntityId` by removing redundant `core::` namespace prefixes for `NonZeroU64` and `AtomicU64`. This improves readability and reduces verbosity. (`crates/sillyecs/src/entity_id.rs`, [crates/sillyecs/src/entity_id.rsR1-R6](diffhunk://#diff-15dee9ca463581490adda93d8920b9938304f0ae2215f3c5103a92a2404784e8R1-R6))

* Updated the `EntityId` implementation to consistently use the simplified `NonZeroU64` and `AtomicU64` types throughout its methods and type conversions. (`crates/sillyecs/src/entity_id.rs`, [[1]](diffhunk://#diff-15dee9ca463581490adda93d8920b9938304f0ae2215f3c5103a92a2404784e8L16-R25) [[2]](diffhunk://#diff-15dee9ca463581490adda93d8920b9938304f0ae2215f3c5103a92a2404784e8L38-R42)

### New `WorldId` type:

* Introduced a `WorldId` struct in a new `world_id` module, similar to `EntityId`, to provide unique identifiers for worlds. This includes a thread-safe counter for generating unique IDs, utility methods, and type conversions. (`crates/sillyecs/src/world_id.rs`, [crates/sillyecs/src/world_id.rsR1-R58](diffhunk://#diff-0568935e8f286e333f32644450daa9e0bd6dad6c973938a726f6af1d54a58796R1-R58))

* Updated `lib.rs` to include the new `world_id` module and re-export the `WorldId` type, making it accessible to other parts of the codebase. (`crates/sillyecs/src/lib.rs`, [crates/sillyecs/src/lib.rsR7-R12](diffhunk://#diff-1e7dc5c478c05bf527a2488a0909bc8c1d26486c0e3bc18174c3743de40d1de5R7-R12))