### PR TITLE
Move more types to the utility crate

### DIFF
--- a/crates/sillyecs-build/templates/systems.rs.jinja2
+++ b/crates/sillyecs-build/templates/systems.rs.jinja2
@@ -208,7 +208,7 @@ impl System{{ phase.name.type }}Events for NoOpPhaseEvents {
     #[inline]
     fn on_begin_phase(
         &mut self,
-        _context: &FrameContext,
+        _context: &::sillyecs::FrameContext,
         {%- for state in phase.states %}
             {%- set access = state.begin_phase | default(value="none") %}
             {%- if access == "none" %}
@@ -229,7 +229,7 @@ impl System{{ phase.name.type }}Events for NoOpPhaseEvents {
     fn on_end_phase(
         &mut self,
         _result: Option<Self::Result>,
-        _context: &FrameContext,
+        _context: &::sillyecs::FrameContext,
         {%- for state in phase.states %}
             {%- set access = state.end_phase | default(value="none") %}
             {%- if access == "none" %}
@@ -257,7 +257,7 @@ pub trait System{{ phase.name.type }}Events {
     /// Executed at the beginning of the phase (before all systems).
     fn on_begin_phase(
         &mut self,
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- for state in phase.states %}
             {%- set access = state.begin_phase | default(value="none") %}
             {%- if access == "none" %}
@@ -279,7 +279,7 @@ pub trait System{{ phase.name.type }}Events {
     fn on_end_phase(
         &mut self,
         result: Option<Self::Result>,
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- for state in phase.states %}
             {%- set access = state.end_phase | default(value="none") %}
             {%- if access == "none" %}
@@ -341,7 +341,7 @@ pub trait Apply{{ system.name.type }}: System {
     fn is_ready(
         &self,
         {%- if system.needs_context %}
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- for state in system.states %}
             {%- set access = state.check | default(value="none") %}
@@ -368,7 +368,7 @@ pub trait Apply{{ system.name.type }}: System {
     fn on_begin_phase(
         &mut self,
         {%- if system.needs_context %}
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- for state in system.states %}
             {%- set access = state.begin_phase | default(value="none") %}
@@ -395,7 +395,7 @@ pub trait Apply{{ system.name.type }}: System {
     fn on_end_phase(
         &mut self,
         {%- if system.needs_context %}
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- for state in system.states %}
             {%- set access = state.end_phase | default(value="none") %}
@@ -430,7 +430,7 @@ pub trait Apply{{ system.name.type }}: System {
     fn preflight(
         &mut self,
         {%- if system.needs_context %}
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- if (system.lookup | count) > 0 %}
         lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
@@ -479,7 +479,7 @@ pub trait Apply{{ system.name.type }}: System {
     fn postflight(
         &mut self,
         {%- if system.needs_context %}
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- if (system.lookup | count) > 0 %}
         lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
@@ -527,7 +527,7 @@ pub trait Apply{{ system.name.type }}: System {
     fn apply_single(
         &mut self,
         {%- if system.needs_context %}
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- for state in system.states %}
             {%- set access = state.system | default(value="none") %}
@@ -569,7 +569,7 @@ pub trait Apply{{ system.name.type }}: System {
     fn apply_many(
         &mut self,
         {%- if system.needs_context %}
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- for state in system.states %}
             {%- set access = state.system | default(value="none") %}
@@ -634,7 +634,7 @@ impl {{ system.name.type }} {
     pub fn apply_single(
         &mut self,
         {%- if system.needs_context %}
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- for state in system.states %}
             {%- set access = state.system | default(value="none") %}
@@ -703,7 +703,7 @@ impl {{ system.name.type }} {
     fn apply_many(
         &mut self,
         {%- if system.needs_context %}
-        context: &FrameContext,
+        context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- for state in system.states %}
             {%- set access = state.system | default(value="none") %}

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -51,58 +51,6 @@ where
     T: WorldCommandSender<UserCommand = U> + WorldCommandReceiver<UserCommand = U>
 { }
 
-/// A frame context.
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct FrameContext {
-    /// The world ID.
-    pub world_id: ::sillyecs::WorldId,
-    /// The frame number.
-    pub frame_number: u64,
-    /// The delta time since the last frame.
-    pub delta_time_secs: f32,
-    /// The fixed time for fixed-time systems. Defaults to 60 Hz (~16.66 ms).
-    pub fixed_time_secs: f32,
-    /// The start time of the current frame.
-    pub current_frame_start: std::time::Instant,
-    /// The start time of the last frame.
-    pub last_frame_start: std::time::Instant,
-}
-
-#[allow(dead_code)]
-impl FrameContext {
-    /// Constructs a new frame context.
-    fn new(world_id: ::sillyecs::WorldId) -> Self {
-        Self {
-            world_id,
-            frame_number: 0,
-            delta_time_secs: 0.0,
-            fixed_time_secs: 1.0 / 60.0,
-            current_frame_start: std::time::Instant::now(),
-            last_frame_start: std::time::Instant::now(),
-        }
-    }
-
-    /// Resets the frame context, e.g. after the application came back to foreground.
-    fn reset(&mut self) {
-        self.current_frame_start = std::time::Instant::now();
-        self.last_frame_start = std::time::Instant::now();
-    }
-}
-
-/// Marker trait for worlds.
-#[allow(dead_code)]
-pub trait World {
-    /// The ID of this world.
-    const ID: ::sillyecs::WorldId;
-
-    /// The ID of this world.
-    #[inline]
-    #[allow(dead_code)]
-    fn id(&self) -> ::sillyecs::WorldId {
-        Self::ID
-    }
-}
 {%- if ecs.any_phase_on_request %}
 
 /// Spawns an entity into the world.
@@ -164,7 +112,7 @@ pub struct {{ world.name.type }}<E, Q> {
     phase_flags: ConditionalPhaseFlags,
     {%- endif %}
     /// The frame context.
-    context: FrameContext,
+    context: ::sillyecs::FrameContext,
     {%- if ecs.any_phase_fixed %}
     /// The fixed-time accumulators.
     fixed_accumulators: FixedAccumulators,
@@ -180,7 +128,7 @@ pub struct {{ world.name.type }}<E, Q> {
     command_queue: Q
 }
 
-impl<E, Q> World for {{ world.name.type }}<E, Q> {
+impl<E, Q> ::sillyecs::World for {{ world.name.type }}<E, Q> {
     const ID: ::sillyecs::WorldId = ::sillyecs::WorldId::new_from(core::num::NonZeroU64::new({{ world.id }}).expect("Invalid ID on ECS construction time"));
 }
 {%- if (world.states | length) > 0 %}
@@ -357,7 +305,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         E: SystemPhaseEvents,
         Q: WorldCommandQueue
     {
-        let context = FrameContext::new(Self::ID);
+        let context = ::sillyecs::FrameContext::new(<Self as ::sillyecs::World>::ID);
         Self {
             archetypes: Default::default(),
             systems: {{ world.name.type }}Systems {

--- a/crates/sillyecs/src/frame_context.rs
+++ b/crates/sillyecs/src/frame_context.rs
@@ -1,0 +1,42 @@
+use crate::WorldId;
+
+/// A frame context.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct FrameContext {
+    /// The world ID.
+    pub world_id: WorldId,
+    /// The frame number.
+    pub frame_number: u64,
+    /// The delta time since the last frame.
+    pub delta_time_secs: f32,
+    /// The fixed time for fixed-time systems. Defaults to 60 Hz (~16.66 ms).
+    pub fixed_time_secs: f32,
+    /// The start time of the current frame.
+    pub current_frame_start: std::time::Instant,
+    /// The start time of the last frame.
+    pub last_frame_start: std::time::Instant,
+}
+
+#[allow(dead_code)]
+impl FrameContext {
+    /// Constructs a new frame context.
+    #[doc(hidden)]
+    pub fn new(world_id: WorldId) -> Self {
+        Self {
+            world_id,
+            frame_number: 0,
+            delta_time_secs: 0.0,
+            fixed_time_secs: 1.0 / 60.0,
+            current_frame_start: std::time::Instant::now(),
+            last_frame_start: std::time::Instant::now(),
+        }
+    }
+
+    /// Resets the frame context, e.g. after the application came back to foreground.
+    #[doc(hidden)]
+    pub fn reset(&mut self) {
+        self.current_frame_start = std::time::Instant::now();
+        self.last_frame_start = std::time::Instant::now();
+    }
+}

--- a/crates/sillyecs/src/lib.rs
+++ b/crates/sillyecs/src/lib.rs
@@ -4,9 +4,13 @@ mod archetypes;
 mod entity_id;
 mod flatten_slices;
 mod flatten_slices_mut;
+mod frame_context;
+mod world;
 mod world_id;
 
 pub use entity_id::EntityId;
 pub use flatten_slices::FlattenSlices;
 pub use flatten_slices_mut::FlattenSlicesMut;
+pub use frame_context::FrameContext;
+pub use world::World;
 pub use world_id::WorldId;

--- a/crates/sillyecs/src/world.rs
+++ b/crates/sillyecs/src/world.rs
@@ -1,0 +1,15 @@
+use crate::WorldId;
+
+/// Marker trait for worlds.
+#[allow(dead_code)]
+pub trait World {
+    /// The ID of this world.
+    const ID: WorldId;
+
+    /// The ID of this world.
+    #[inline]
+    #[allow(dead_code)]
+    fn id(&self) -> WorldId {
+        Self::ID
+    }
+}


### PR DESCRIPTION
This pull request refactors the `FrameContext` struct and related code to improve modularity and align with the `sillyecs` framework. The most significant changes include moving `FrameContext` and `World` definitions to dedicated modules, updating references across the codebase, and simplifying the `world.rs.jinja2` template.

### Refactoring and Modularization

* Moved the `FrameContext` struct from `world.rs.jinja2` to a new module `frame_context.rs` under `crates/sillyecs/src`. This includes all related methods, such as `new` and `reset`. (`[[1]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L54-L105)`, `[[2]](diffhunk://#diff-df112097822bc2fdafb978c1b8107159920da5ca621dd86b07c2a196a6e7e0ebR1-R42)`)
* Moved the `World` trait from `world.rs.jinja2` to a new module `world.rs` under `crates/sillyecs/src`. (`[[1]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L183-R131)`, `[[2]](diffhunk://#diff-da2e7e5c983dfbba5166f97bdc387601052efa4b4787bc1b6d7ed7a324b4ed4eR1-R15)`)

### Codebase Updates for New Module Structure

* Updated all references to `FrameContext` to use the fully qualified path `::sillyecs::FrameContext` in `systems.rs.jinja2` and `world.rs.jinja2`. (`[[1]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L211-R211)`, `[[2]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L232-R232)`, `[[3]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L260-R260)`, `[[4]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L282-R282)`, `[[5]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L344-R344)`, `[[6]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L371-R371)`, `[[7]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L398-R398)`, `[[8]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L433-R433)`, `[[9]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L482-R482)`, `[[10]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L530-R530)`, `[[11]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L572-R572)`, `[[12]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L637-R637)`, `[[13]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L706-R706)`, `[[14]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L167-R115)`, `[[15]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L360-R308)`)
* Updated `lib.rs` to include the new `frame_context` and `world` modules and re-export `FrameContext` and `World`. (`[crates/sillyecs/src/lib.rsR7-R15](diffhunk://#diff-1e7dc5c478c05bf527a2488a0909bc8c1d26486c0e3bc18174c3743de40d1de5R7-R15)`)

### Simplification of Templates

* Removed the inline definition of `FrameContext` and `World` from `world.rs.jinja2`, reducing redundancy and improving maintainability. (`[[1]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L54-L105)`, `[[2]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L183-R131)`)