### PR TITLE
Add apply_all function taking array of component slices

### DIFF
--- a/crates/sillyecs-build/templates/systems.rs.jinja2
+++ b/crates/sillyecs-build/templates/systems.rs.jinja2
@@ -625,6 +625,77 @@ pub trait Apply{{ system.name.type }}: System {
             );
         }
     }
+
+    /// Applies the system's business logic to the given entity components.
+    ///
+    /// ### Reads
+    /// {% for input in system.inputs %}
+    /// - `{{ input.field }}`: A slice of the input components of type [`{{ input.type }}`].{% endfor %}
+    ///
+    /// ### Mutates
+    /// {% for output in system.outputs %}
+    /// - `{{ output.field }}`: A mutable slice of the components of type [`{{ output.type }}`].{% endfor %}
+    #[allow(unused_mut)]
+    fn apply_all(
+        &mut self,
+        {%- if system.needs_context %}
+        context: &::sillyecs::FrameContext,
+        {%- endif %}
+        {%- for state in system.states %}
+            {%- set access = state.system | default(value="none") %}
+            {%- if access == "none" %}
+                {# skip #}
+            {%- elif access == "read" %}
+                {{ state.use.field }}: &{{ state.use.type }},
+            {%- elif access == "write" %}
+                {{ state.use.field }}: &mut {{ state.use.type }},
+            {%- else %}
+                todo!("Invalid state use in ECS construction"),
+            {%- endif %}
+        {%- endfor %}
+        {%- if system.needs_entities %}
+        entities: [&[::sillyecs::EntityId]; {{ system.affected_archetype_count }}],
+        {%- endif %}
+        {%- for input in system.inputs %}
+        {{ input.fields }}: [&[{{ input.type }}]; {{ system.affected_archetype_count }}],
+        {%- endfor %}
+        {%- for output in system.outputs %}
+        mut {{ output.fields }}: [&mut [{{ output.type }}]; {{ system.affected_archetype_count }}],
+        {%- endfor %}
+        {%- if system.emits_commands %}
+        commands: &impl WorldCommandSender
+        {%- endif %}
+    ) {
+        let zipped_iter = {{ system.component_iter_code }};
+        for {{ system.component_untuple_code }} in zipped_iter {
+            Apply{{ system.name.type }}::apply_many(
+                self,
+                {%- if system.needs_context %}
+                context,
+                {%- endif %}
+                {%- for state in system.states %}
+                    {%- set access = state.system | default(value="none") %}
+                    {%- if access == "none" %}
+                        {# skip #}
+                    {%- else %}
+                        {{ state.use.field }},
+                    {%- endif %}
+                {%- endfor %}
+                {%- if system.needs_entities %}
+                entity,
+                {%- endif %}
+                {%- for input in system.inputs %}
+                {{ input.field }},
+                {%- endfor %}
+                {%- for output in system.outputs %}
+                {{ output.field }},
+                {%- endfor %}
+                {%- if system.emits_commands %}
+                commands
+                {%- endif %}
+            );
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/sillyecs-build/templates/systems.rs.jinja2
+++ b/crates/sillyecs-build/templates/systems.rs.jinja2
@@ -701,67 +701,6 @@ pub trait Apply{{ system.name.type }}: System {
 
 #[allow(dead_code)]
 impl {{ system.name.type }} {
-    /// Apply the system to the given entity components
-    #[inline]
-    pub fn apply_single(
-        &mut self,
-        {%- if system.needs_context %}
-        context: &::sillyecs::FrameContext,
-        {%- endif %}
-        {%- for state in system.states %}
-            {%- set access = state.system | default(value="none") %}
-            {%- if access == "none" %}
-                {# skip #}
-            {%- elif access == "read" %}
-                {{ state.use.field }}: &{{ state.use.type }},
-            {%- elif access == "write" %}
-                {{ state.use.field }}: &mut {{ state.use.type }},
-            {%- else %}
-                todo!("Invalid state use in ECS construction"),
-            {%- endif %}
-        {%- endfor %}
-        {%- if system.needs_entities %}
-        entity: ::sillyecs::EntityId,
-        {%- endif %}
-        {%- for input in system.inputs %}
-        {{ input.field }}: &{{ input.type }},
-        {%- endfor %}
-        {%- for output in system.outputs %}
-        {{ output.field }}: &mut {{ output.type }},
-        {%- endfor %}
-        {%- if system.emits_commands %}
-        commands: &impl WorldCommandSender
-        {%- endif %}
-    ) {
-        // Force the implementation of the Apply{{ system.name.type }} trait.
-        Apply{{ system.name.type }}::apply_single(
-            self,
-            {%- if system.needs_context %}
-            context,
-            {%- endif %}
-            {%- for state in system.states %}
-                {%- set access = state.system | default(value="none") %}
-                {%- if access == "none" %}
-                    {# skip #}
-                {%- else %}
-                    {{ state.use.field }},
-                {%- endif %}
-            {%- endfor %}
-            {%- if system.needs_entities %}
-            entity,
-            {%- endif %}
-            {%- for input in system.inputs %}
-            {{ input.field }},
-            {%- endfor %}
-            {%- for output in system.outputs %}
-            {{ output.field }},
-            {%- endfor %}
-            {%- if system.emits_commands %}
-            commands
-            {%- endif %}
-        );
-    }
-
     /// Applies the system's business logic to the given entity components.
     ///
     /// ### Reads
@@ -771,7 +710,7 @@ impl {{ system.name.type }} {
     /// ### Mutates
     /// {% for output in system.outputs %}
     /// - `{{ output.field }}`: A mutable slice of the components of type [`{{ output.type }}`].{% endfor %}
-    #[inline]
+    #[inline(always)]
     fn apply_many(
         &mut self,
         {%- if system.needs_context %}
@@ -779,12 +718,11 @@ impl {{ system.name.type }} {
         {%- endif %}
         {%- for state in system.states %}
             {%- set access = state.system | default(value="none") %}
-            {%- if access == "none" %}
-                {# skip #}
+            {%- if access == "none" %}{# skip #}
             {%- elif access == "read" %}
-                {{ state.use.field }}: &{{ state.use.type }},
+        {{ state.use.field }}: &{{ state.use.type }},
             {%- elif access == "write" %}
-                {{ state.use.field }}: &mut {{ state.use.type }},
+        {{ state.use.field }}: &mut {{ state.use.type }},
             {%- else %}
                 todo!("Invalid state use in ECS construction"),
             {%- endif %}
@@ -810,10 +748,9 @@ impl {{ system.name.type }} {
             {%- endif %}
             {%- for state in system.states %}
                 {%- set access = state.system | default(value="none") %}
-                {%- if access == "none" %}
-                    {# skip #}
+                {%- if access == "none" %}{# skip #}
                 {%- else %}
-                    {{ state.use.field }},
+            {{ state.use.field }},
                 {%- endif %}
             {%- endfor %}
             {%- if system.needs_entities %}
@@ -829,6 +766,75 @@ impl {{ system.name.type }} {
             commands
             {%- endif %}
         );
+    }
+
+    /// Applies the system's business logic to the given entity components.
+    ///
+    /// ### Reads
+    /// {% for input in system.inputs %}
+    /// - `{{ input.field }}`: A slice of the input components of type [`{{ input.type }}`].{% endfor %}
+    ///
+    /// ### Mutates
+    /// {% for output in system.outputs %}
+    /// - `{{ output.field }}`: A mutable slice of the components of type [`{{ output.type }}`].{% endfor %}
+    #[allow(unused_mut)]
+    #[inline]
+    fn apply_all(
+        &mut self,
+        {%- if system.needs_context %}
+        context: &::sillyecs::FrameContext,
+        {%- endif %}
+        {%- for state in system.states %}
+            {%- set access = state.system | default(value="none") %}
+            {%- if access == "none" %}{# skip #}
+            {%- elif access == "read" %}
+        {{ state.use.field }}: &{{ state.use.type }},
+            {%- elif access == "write" %}
+        {{ state.use.field }}: &mut {{ state.use.type }},
+            {%- else %}
+                todo!("Invalid state use in ECS construction"),
+            {%- endif %}
+        {%- endfor %}
+        {%- if system.needs_entities %}
+        entities: [&[::sillyecs::EntityId]; {{ system.affected_archetype_count }}],
+        {%- endif %}
+        {%- for input in system.inputs %}
+        {{ input.fields }}: [&[{{ input.type }}]; {{ system.affected_archetype_count }}],
+        {%- endfor %}
+        {%- for output in system.outputs %}
+        mut {{ output.fields }}: [&mut [{{ output.type }}]; {{ system.affected_archetype_count }}],
+        {%- endfor %}
+        {%- if system.emits_commands %}
+        commands: &impl WorldCommandSender
+        {%- endif %}
+    ) {
+        let zipped_iter = {{ system.component_iter_code }};
+        for {{ system.component_untuple_code }} in zipped_iter {
+            self.apply_many(
+                {%- if system.needs_context %}
+                context,
+                {%- endif %}
+                {%- for state in system.states %}
+                    {%- set access = state.system | default(value="none") %}
+                    {%- if access == "none" %}{# skip #}
+                    {%- else %}
+                {{ state.use.field }},
+                    {%- endif %}
+                {%- endfor %}
+                {%- if system.needs_entities %}
+                entity,
+                {%- endif %}
+                {%- for input in system.inputs %}
+                {{ input.field }},
+                {%- endfor %}
+                {%- for output in system.outputs %}
+                {{ output.field }},
+                {%- endfor %}
+                {%- if system.emits_commands %}
+                commands
+                {%- endif %}
+            );
+        }
     }
 }
 

--- a/crates/sillyecs-build/templates/systems.rs.jinja2
+++ b/crates/sillyecs-build/templates/systems.rs.jinja2
@@ -636,6 +636,7 @@ pub trait Apply{{ system.name.type }}: System {
     /// {% for output in system.outputs %}
     /// - `{{ output.field }}`: A mutable slice of the components of type [`{{ output.type }}`].{% endfor %}
     #[allow(unused_mut)]
+    #[inline]
     fn apply_all(
         &mut self,
         {%- if system.needs_context %}

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -961,6 +961,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         {%- endfor %}
 
         {
+            // TODO: Skip spawning thread here when there is only one system, or when all run in sequence
             rayon::scope(|s| {
                 // TODO: Instead of parallelizing systems (and then have them access archetypes), parallelize archetypes and apply all systems. This should improve data parallelism because it keeps caches hot.
                 {%- for system in group %}
@@ -1011,9 +1012,30 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
 
                         // Systems
                         {
-                            {%- for archetype in system.affected_archetypes %}
-                            // Apply {{ system.name.type }} to {{ archetype.type }}
-                            self.systems.{{ system.name.field }}.apply_many(
+                            {%- if system.needs_entities %}
+                            let entities: [&[::sillyecs::EntityId]; {{ system.affected_archetypes | length }}] = [
+                                {%- for archetype in system.affected_archetypes %}
+                                &self.archetypes.collection.{{ archetype.field }}.entities,
+                                {%- endfor %}
+                            ];
+                            {%- endif %}
+                            {%- for input in system.inputs %}
+                            let {{ input.field }}_inputs: [&[{{ input.type }}]; {{ system.affected_archetypes | length }}] = [
+                                {%- for archetype in system.affected_archetypes %}
+                                &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
+                                {%- endfor %}
+                            ];
+                            {%- endfor %}
+                            {%- for output in system.outputs %}
+                            let {{ output.field }}_outputs: [&mut [{{ output.type }}]; {{ system.affected_archetypes | length }}] = [
+                                {%- for archetype in system.affected_archetypes %}
+                                &mut self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
+                                {%- endfor %}
+                            ];
+                            {%- endfor %}
+
+                            // Apply {{ system.name.type }} to all archetypes
+                            self.systems.{{ system.name.field }}.apply_all(
                                 {%- if system.needs_context %}
                                 &self.context,
                                 {%- endif %}
@@ -1030,19 +1052,18 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                                     {%- endif %}
                                 {%- endfor %}
                                 {%- if system.needs_entities %}
-                                &self.archetypes.collection.{{ archetype.field }}.entities,
+                                entities,
                                 {%- endif %}
                                 {%- for input in system.inputs %}
-                                &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
+                                {{ input.field }}_inputs,
                                 {%- endfor %}
                                 {%- for output in system.outputs %}
-                                &mut self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
+                                {{ output.field }}_outputs,
                                 {%- endfor %}
                                 {%- if system.emits_commands %}
                                 &self.command_queue
                                 {%- endif %}
                             );
-                            {%- endfor %}
                         }
 
                         // Postflight

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -746,9 +746,30 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
 
             // Systems
             {
-                {%- for archetype in system.affected_archetypes %}
-                // Apply {{ system.name.type }} to {{ archetype.type }}
-                self.systems.{{ system.name.field }}.apply_many(
+                {%- if system.needs_entities %}
+                let entities: [&[::sillyecs::EntityId]; {{ system.affected_archetypes | length }}] = [
+                    {%- for archetype in system.affected_archetypes %}
+                    &self.archetypes.collection.{{ archetype.field }}.entities,
+                    {%- endfor %}
+                ];
+                {%- endif %}
+                {%- for input in system.inputs %}
+                let {{ input.field }}_inputs: [&[{{ input.type }}]; {{ system.affected_archetypes | length }}] = [
+                    {%- for archetype in system.affected_archetypes %}
+                    &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
+                    {%- endfor %}
+                ];
+                {%- endfor %}
+                {%- for output in system.outputs %}
+                let {{ output.field }}_outputs: [&mut [{{ output.type }}]; {{ system.affected_archetypes | length }}] = [
+                    {%- for archetype in system.affected_archetypes %}
+                    &mut self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
+                    {%- endfor %}
+                ];
+                {%- endfor %}
+
+                // Apply {{ system.name.type }} to all archetypes
+                self.systems.{{ system.name.field }}.apply_all(
                     {%- if system.needs_context %}
                     &self.context,
                     {%- endif %}
@@ -765,19 +786,18 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                         {%- endif %}
                     {%- endfor %}
                     {%- if system.needs_entities %}
-                    &self.archetypes.collection.{{ archetype.field }}.entities,
+                    entities,
                     {%- endif %}
                     {%- for input in system.inputs %}
-                    &self.archetypes.collection.{{ archetype.field }}.{{ input.fields }},
+                    {{ input.field }}_inputs,
                     {%- endfor %}
                     {%- for output in system.outputs %}
-                    &mut self.archetypes.collection.{{ archetype.field }}.{{ output.fields }},
+                    {{ output.field }}_outputs,
                     {%- endfor %}
                     {%- if system.emits_commands %}
                     &self.command_queue
                     {%- endif %}
                 );
-                {%- endfor %}
             }
 
             // Postflight


### PR DESCRIPTION
This pull request refactors the ECS (Entity-Component-System) code generation templates to improve system application logic, streamline archetype handling, and enhance parallelization strategies. The changes primarily focus on introducing support for batch processing of entities and components, improving the readability and maintainability of the generated code, and laying the groundwork for future optimizations.

### System Application Refactor:
* Replaced `apply_single` with `apply_all` and `apply_many` methods to enable batch processing of entities and components. The `apply_all` method iterates over archetypes and invokes `apply_many` for each batch of components. (`crates/sillyecs-build/templates/systems.rs.jinja2`, [[1]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L628-R640) [[2]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3L652-R672) [[3]](diffhunk://#diff-079edf544241bb432415f16ddbb0aaa83ce3a3bb2fdc8aaedf50f205f3eb64a3R770-R838)

### Archetype and Component Handling:
* Introduced arrays for entities, inputs, and outputs in the `apply_all` method to handle multiple archetypes in a single invocation. This improves data locality and simplifies the code. (`crates/sillyecs-build/templates/systems.rs.jinja2`, [[1]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0R749-R772) [[2]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L768-L780)

### Parallelization Enhancements:
* Added a TODO comment to explore skipping thread spawning when only one system is present or when systems run sequentially, as well as to consider parallelizing archetypes instead of systems for better cache utilization. (`crates/sillyecs-build/templates/world.rs.jinja2`, [crates/sillyecs-build/templates/world.rs.jinja2R964](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0R964))

### Code Simplification:
* Consolidated redundant logic and improved readability by replacing individual archetype handling with batch processing logic. This includes the use of arrays for entities, inputs, and outputs in parallelized system application code. (`crates/sillyecs-build/templates/world.rs.jinja2`, [[1]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0R1015-R1038) [[2]](diffhunk://#diff-b652f6d89a6e130b9081cd6c50de695150aeba3d4e9c23c8270812236ee4d9b0L1013-L1025)