### PR TITLE
Add iteration of entity IDs

### DIFF
--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -1634,6 +1634,10 @@ where
     type UserCommand = U;
 }
 {%- endfor %}
+
+/// An iterator over [`EntityId`](::sillyecs::EntityId) values.
+#[allow(dead_code)]
+pub type EntityIdIter<'a> = ::sillyecs::FlattenCopySlices<'a, ::sillyecs::EntityId>;
 {%- for component in ecs.components %}
 
 /// An iterator over all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
@@ -1653,6 +1657,16 @@ pub trait Iter{{ component.name.raw }}Components<'a> {
 
     /// Iterates all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
     fn iter_{{ component.name.fields }}(&'a self) -> Self::Iterator;
+}
+
+/// A trait for types allowing to iterate the [`EntityId`](::sillyecs::EntityId) values
+/// of all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
+#[allow(dead_code)]
+pub trait Iter{{ component.name.raw }}Entities<'a> {
+    type Iterator: core::iter::Iterator<Item = ::sillyecs::EntityId>;
+
+    /// Iterates all entity IDs of [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
+    fn iter_{{ component.name.field }}_entities(&'a self) -> Self::Iterator;
 }
 
 /// A trait for types allowing to iterate all [`{{ component.name.raw }}`]({{ component.name.type }}) components, regardless of archetype.
@@ -1682,6 +1696,26 @@ impl<'a, E, Q> Iter{{ component.raw }}Components<'a> for {{ world.name.type }}<E
             {%- for arch_comp in archetype.components %}
             {%- if arch_comp.type == component.type %}
             &self.archetypes.collection.{{archetype.name.field}}.{{ arch_comp.fields }},
+            {%- endif %}
+            {%- endfor %}
+            {%- endfor %}
+        ])
+    }
+}
+
+#[allow(dead_code)]
+impl<'a, E, Q> Iter{{ component.raw }}Entities<'a> for {{ world.name.type }}<E, Q>
+{
+    type Iterator = EntityIdIter<'a>;
+
+    /// Iterates all entity IDs of [`{{ component.raw }}`]({{ component.type }}) components, regardless of archetype.
+    fn iter_{{ component.field }}_entities(&'a self) -> Self::Iterator {
+        // TODO: Simplify to ::core::slice::Iter<> if only one archetype has this component.
+        EntityIdIter::new([
+            {%- for archetype in world.archetypes %}
+            {%- for arch_comp in archetype.components %}
+            {%- if arch_comp.type == component.type %}
+            &self.archetypes.collection.{{archetype.name.field}}.entities,
             {%- endif %}
             {%- endfor %}
             {%- endfor %}

--- a/crates/sillyecs/src/flatten_copy_slices.rs
+++ b/crates/sillyecs/src/flatten_copy_slices.rs
@@ -1,0 +1,95 @@
+use std::borrow::Cow;
+use std::iter::FusedIterator;
+
+/// An iterator over a slice of slices.
+///
+/// Presents the inner slices as one contiguous set of data.
+#[derive(Debug)]
+pub struct FlattenCopySlices<'a, T>
+where
+    T: Copy,
+{
+    slices: Cow<'a, [&'a [T]]>,
+    front: (usize, usize), // (slice index, element index)
+}
+
+impl<'a, T> FlattenCopySlices<'a, T>
+where
+    T: Copy,
+{
+    pub fn new<const N: usize>(slices: [&'a [T]; N]) -> Self {
+        let slices = Cow::Owned(slices.into());
+        Self {
+            slices,
+            front: (0, 0),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.front = (0, 0);
+    }
+}
+
+impl<'a, T> Iterator for FlattenCopySlices<'a, T>
+where
+    T: Copy,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.front.0 < self.slices.len() {
+            let (slice_idx, elem_idx) = self.front;
+            let slice = &self.slices[slice_idx];
+
+            if elem_idx < slice.len() {
+                self.front.1 += 1;
+
+                if self.front.1 >= slice.len() {
+                    self.front.0 += 1;
+                    self.front.1 = 0;
+                }
+
+                return Some(slice[elem_idx]);
+            }
+
+            self.front.0 += 1;
+            self.front.1 = 0;
+        }
+
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut count = 0;
+        for i in self.front.0..self.slices.len() {
+            let slice = &self.slices[i];
+            let start = if i == self.front.0 { self.front.1 } else { 0 };
+            count += slice.len().saturating_sub(start);
+        }
+        (count, Some(count))
+    }
+}
+
+impl<'a, T> ExactSizeIterator for FlattenCopySlices<'a, T> where T: Copy {}
+impl<'a, T> FusedIterator for FlattenCopySlices<'a, T> where T: Copy {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_forward() {
+        let s1 = &[1, 2][..];
+        let s2 = &[3][..];
+        let s3 = &[][..];
+        let s4 = &[4, 5, 6][..];
+
+        let iter = FlattenCopySlices::new([s1, s2, s3, s4]);
+
+        let size = iter.len();
+        assert_eq!(size, 6);
+        assert_eq!(iter.size_hint(), (6, Some(6)));
+
+        assert_eq!(iter.collect::<Vec<i32>>(), &[1, 2, 3, 4, 5, 6]);
+    }
+}

--- a/crates/sillyecs/src/lib.rs
+++ b/crates/sillyecs/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod archetypes;
 mod entity_id;
+mod flatten_copy_slices;
 mod flatten_slices;
 mod flatten_slices_mut;
 mod frame_context;
@@ -9,6 +10,7 @@ mod world;
 mod world_id;
 
 pub use entity_id::EntityId;
+pub use flatten_copy_slices::FlattenCopySlices;
 pub use flatten_slices::FlattenSlices;
 pub use flatten_slices_mut::FlattenSlicesMut;
 pub use frame_context::FrameContext;


### PR DESCRIPTION
This pull request introduces a new iterator type, `FlattenCopySlices`, to streamline iteration over slices of slices, and integrates it into the `sillyecs` library for iterating over `EntityId` values. The changes also include the addition of a new trait and its implementation to support entity ID iteration for components.

### New Iterator Implementation

* Added a new `FlattenCopySlices` struct in `crates/sillyecs/src/flatten_copy_slices.rs`. This iterator allows treating a slice of slices as a single contiguous set of data. It includes methods like `new` for initialization, `reset` for resetting the iterator, and implements traits such as `Iterator`, `ExactSizeIterator`, and `FusedIterator` for seamless use. A test suite is also provided to validate its functionality.

### Library Integration

* Updated `crates/sillyecs/src/lib.rs` to expose the `FlattenCopySlices` type for use across the library.

### Entity ID Iteration in Code Generation

* Added an `EntityIdIter` type alias in `crates/sillyecs-build/templates/world.rs.jinja2` for iterating over `EntityId` values.
* Introduced a new trait, `Iter{{ component.name.raw }}Entities`, in `crates/sillyecs-build/templates/world.rs.jinja2`. This trait provides a method to iterate over the `EntityId` values of all components of a specific type, regardless of archetype.
* Implemented the `Iter{{ component.raw }}Entities` trait for the generated `World` type in `crates/sillyecs-build/templates/world.rs.jinja2`, using the `FlattenCopySlices` iterator.