### PR TITLE
Fix codegen template bugs and document features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /target
 /Cargo.lock
 .env
+
+# Local checkout of private downstream consumers used for integration testing.
+# Must never be committed.
+/.retro/

--- a/README.md
+++ b/README.md
@@ -10,13 +10,60 @@ A silly little compile-time generated archetype ECS in Rust.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+- [Features](#features)
 - [Installation](#installation)
 - [Usage](#usage)
-    - [Command Queue and Application-Specific Commands](#command-queue-and-application-specific-commands)
+  - [Command Queue and Application-Specific Commands](#command-queue-and-application-specific-commands)
 - [Examples](#examples)
-    - [WGPU Shader Compilation](#wgpu-shader-compilation)
+  - [WGPU Shader Compilation](#wgpu-shader-compilation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Features
+
+`sillyecs` generates a fully monomorphized ECS at build time from a YAML schema. There is no
+type-erased component storage, no dynamic dispatch in the hot path, and no runtime registration.
+The runtime crate is intentionally tiny; nearly all behavior lives in the code that is generated
+into your project.
+
+- **Compile-time codegen.** A YAML schema describes components, archetypes, systems, phases,
+  worlds, and user states. `sillyecs-build` validates it (duplicate components, undefined
+  references, cyclic system dependencies, archetype coverage, …) and emits strongly-typed Rust
+  via Jinja2 templates.
+- **Archetype storage in Struct-of-Arrays layout.** Each archetype keeps a `Vec<EntityId>` and one
+  `Vec<C>` per component, so systems iterate over contiguous component slices and stay
+  cache-friendly.
+- **Automatic system scheduling.** Per phase, the build crate analyzes each system's component
+  reads/writes, user-state reads/writes, frame-context use, and explicit `run_after` edges,
+  resolves bidirectional conflicts via forced-edge reachability, and emits layered groups
+  (Kahn's algorithm) that can run in parallel.
+- **Sequential and Rayon-parallel execution paths.** Every phase gets both
+  `apply_system_phase_X()` and `par_apply_system_phase_X()` variants.
+- **Rich phase lifecycle.** Each system exposes `is_ready` → `on_begin_phase` → optional
+  `preflight` → `apply_single`/`apply_many`/`apply_all` → optional `postflight` → `on_end_phase`,
+  with phase-level `on_begin_phase`/`on_end_phase` events on top.
+- **Fine-grained state access.** User states declared with `use: …` can be configured per
+  lifecycle hook (`check`, `begin_phase`, `preflight`, `system`, `postflight`, `end_phase`) as
+  `none`/`read`/`write`. Generated signatures match exactly; the scheduler accounts for state
+  conflicts the same way it accounts for component conflicts.
+- **Flexible phase types.** Phases can be `manual` (caller drives them), `on_request` (atomic
+  request flag, swap-on-read), or fixed-step with an accumulator loop (`60 Hz` / `0.016 s`
+  syntax).
+- **Deferred world commands.** Spawn, despawn, and user-defined commands flow through a
+  pluggable `WorldCommandSender`/`WorldCommandReceiver`. Commands are drained before and after
+  each phase, not between systems.
+- **`NonZeroU64` IDs.** `ArchetypeId`, `SystemId`, `WorldId`, and `EntityId` are niche-optimized
+  enums with `const` value tables and `Display` impls.
+- **Cross-archetype component iteration.** For every component, generated traits
+  (`IterXComponents`, `IterMutXComponents`, `IterXEntities`) yield flat iterators over every
+  archetype that carries it.
+- **Entity frontloading.** Archetypes support `frontload`/`frontload_by_indices_sorted`/
+  `frontload_scan` to partition entities (e.g. for quadtree-driven culling) without breaking the
+  archetype invariants.
+- **Pluggable `EntityLocationMap`.** The entity → archetype/index lookup is left as a type alias
+  so callers can drop in `fxhash`, `ahash`, or anything else.
+- **Optional unchecked accessors.** Setting `allow_unsafe: true` enables `get_*_unchecked`
+  variants for hot loops; the default safe paths remain available.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ into your project.
 
 ## Installation
 
-`sillyecs` is a maily build-time dependency (`sillyecs-build`) that comes with a utility crate (`sillyecs`).
+`sillyecs` is a mainly build-time dependency (`sillyecs-build`) that comes with a utility crate (`sillyecs`).
 To use them, add this to your `Cargo.toml`:
 
 ```toml

--- a/crates/sillyecs-build/src/code.rs
+++ b/crates/sillyecs-build/src/code.rs
@@ -66,8 +66,6 @@ impl EcsCode {
             ecs => ecs,
         })?;
 
-        println!("{}", component_code);
-        println!("{}", archetype_code);
         Ok(EcsCode {
             components: component_code,
             archetypes: archetype_code,

--- a/crates/sillyecs-build/src/system.rs
+++ b/crates/sillyecs-build/src/system.rs
@@ -132,6 +132,17 @@ impl StateUse {
             || self.postflight.unwrap_or(self.default).is_write()
             || self.end_phase.unwrap_or(self.default).is_write()
     }
+
+    /// Fills every unset lifecycle access hook with [`Self::default`] so templates can rely on
+    /// concrete `none`/`read`/`write` values instead of falling through on null.
+    pub fn apply_defaults(&mut self) {
+        set_default_state(&mut self.check, self.default);
+        set_default_state(&mut self.begin_phase, self.default);
+        set_default_state(&mut self.preflight, self.default);
+        set_default_state(&mut self.system, self.default);
+        set_default_state(&mut self.postflight, self.default);
+        set_default_state(&mut self.end_phase, self.default);
+    }
 }
 
 fn set_default_state(state: &mut Option<AccessType>, default: AccessType) {
@@ -179,12 +190,7 @@ impl System {
 
     fn apply_state_defaults(&mut self) {
         for state in &mut self.states {
-            set_default_state(&mut state.check, state.default);
-            set_default_state(&mut state.begin_phase, state.default);
-            set_default_state(&mut state.preflight, state.default);
-            set_default_state(&mut state.system, state.default);
-            set_default_state(&mut state.postflight, state.default);
-            set_default_state(&mut state.end_phase, state.default);
+            state.apply_defaults();
         }
     }
 
@@ -400,6 +406,10 @@ impl SystemPhase {
                 self.fixed_hertz = 1.0 / sec;
                 self.fixed = true;
             }
+        }
+
+        for state in &mut self.states {
+            state.apply_defaults();
         }
     }
 }

--- a/crates/sillyecs-build/templates/archetypes.rs.jinja2
+++ b/crates/sillyecs-build/templates/archetypes.rs.jinja2
@@ -319,14 +319,14 @@ impl {{ archetype.name.type }} {
     #[allow(dead_code)]
     #[inline]
     pub fn get_{{component.field}}_component_at(&self, index: usize) -> Option<&{{component.type}}> {
-        if index > self.len() {
+        if index >= self.len() {
             return None;
         }
 
         {%- if ecs.allow_unsafe %}
         Some(unsafe { self.get_{{component.field}}_component_at_unchecked(index) })
         {%- else %}
-        Some(&self.{{ component_name.fields }}[index])
+        Some(&self.{{ component.fields }}[index])
         {%- endif %}
     }
 
@@ -334,14 +334,14 @@ impl {{ archetype.name.type }} {
     #[allow(dead_code)]
     #[inline]
     pub fn get_{{component.field}}_component_at_mut(&mut self, index: usize) -> Option<&mut {{component.type}}> {
-        if index > self.len() {
+        if index >= self.len() {
             return None;
         }
 
         {%- if ecs.allow_unsafe %}
         Some(unsafe { self.get_{{component.field}}_component_at_unchecked_mut(index) })
         {%- else %}
-        Some(&mut self.{{ component_name.fields }}[index])
+        Some(&mut self.{{ component.fields }}[index])
         {%- endif %}
     }
 
@@ -364,7 +364,7 @@ impl {{ archetype.name.type }} {
     /// Gets the entity at the specified index.
     #[allow(dead_code)]
     pub fn get_entity_at(&self, index: usize) -> Option<{{ archetype.name.raw }}EntityRef> {
-        if index > self.len() {
+        if index >= self.len() {
             return None;
         }
 
@@ -383,7 +383,7 @@ impl {{ archetype.name.type }} {
     /// Mutably gets the entity at the specified index.
     #[allow(dead_code)]
     pub fn get_entity_at_mut(&mut self, index: usize) -> Option<{{ archetype.name.raw }}EntityMut> {
-        if index > self.len() {
+        if index >= self.len() {
             return None;
         }
 
@@ -572,7 +572,11 @@ impl {{ archetype.name.type }} {
     {%- for promotion in archetype.promotion_infos %}
 
     /// Promotes this [`{{ archetype.name.type }}`] to [`{{ promotion.target.type }}`].
-    #[deprecated]
+    ///
+    /// **Deprecated:** this in-place promotion bypasses the world's entity-location map and
+    /// can leave the world in an inconsistent state. Despawn and respawn through the world
+    /// instead.
+    #[deprecated(note = "Bypasses the world entity location map; despawn and respawn via the world instead.")]
     pub fn promote_to_{{ promotion.target.fields }}(
         self,
         {%- for field in promotion.components_to_add %}

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -542,11 +542,11 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
 
         // The {{ phase.name.raw }} phase is conditional.
         if self.phase_flags.is_{{ phase.name.field }}_requested() {
-            self.apply_system_phase_{{ phase.name.field }}();
+            self.par_apply_system_phase_{{ phase.name.field }}();
         }
         {%- else %}
         // The {{ phase.name.raw }} phase always runs.
-        self.apply_system_phase_{{ phase.name.field }}();
+        self.par_apply_system_phase_{{ phase.name.field }}();
         {%- endif %}
         {%- else %}
         {%- if phase.on_request %}
@@ -557,7 +557,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
             self.context.fixed_time_secs = SystemPhase::{{ phase.name.field | upper }}_SECS;
             self.fixed_accumulators.{{ phase.name.field }} += self.context.delta_time_secs;
             while self.fixed_accumulators.{{ phase.name.field }} >= SystemPhase::{{ phase.name.field | upper }}_SECS {
-                self.apply_system_phase_{{ phase.name.field }}();
+                self.par_apply_system_phase_{{ phase.name.field }}();
                 self.fixed_accumulators.{{ phase.name.field }} -= SystemPhase::{{ phase.name.field | upper }}_SECS;
             }
         }
@@ -567,7 +567,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
         self.context.fixed_time_secs = SystemPhase::{{ phase.name.field | upper }}_SECS;
         self.fixed_accumulators.{{ phase.name.field }} += self.context.delta_time_secs;
         while self.fixed_accumulators.{{ phase.name.field }} >= SystemPhase::{{ phase.name.field | upper }}_SECS {
-            self.apply_system_phase_{{ phase.name.field }}();
+            self.par_apply_system_phase_{{ phase.name.field }}();
             self.fixed_accumulators.{{ phase.name.field }} -= SystemPhase::{{ phase.name.field | upper }}_SECS;
         }
         {%- endif %}

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -456,7 +456,8 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     pub fn apply_system_phases(&mut self)
     where
         E: SystemPhaseEvents,
-        Q: WorldCommandSender + WorldCommandReceiver
+        Q: WorldCommandSender + WorldCommandReceiver,
+        Self: WorldUserCommandHandler<UserCommand = <Q as WorldUserCommand>::UserCommand>,
     {
         self.on_begin_frame();
         self.handle_commands();
@@ -526,7 +527,8 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     pub fn par_apply_system_phases(&mut self)
     where
         E: SystemPhaseEvents,
-        Q: WorldCommandSender + WorldCommandReceiver
+        Q: WorldCommandSender + WorldCommandReceiver,
+        Self: WorldUserCommandHandler<UserCommand = <Q as WorldUserCommand>::UserCommand>,
     {
         self.on_begin_frame();
         self.handle_commands();
@@ -601,7 +603,8 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     fn apply_system_phase_{{ phase.name.field }}(&mut self)
     where
         E: SystemPhaseEvents,
-        Q: WorldCommandSender + WorldCommandReceiver
+        Q: WorldCommandSender + WorldCommandReceiver,
+        Self: WorldUserCommandHandler<UserCommand = <Q as WorldUserCommand>::UserCommand>,
     {
         self.on_begin_{{ phase.name.field }}_phase();
         let result = System{{ phase.name.type }}Events::on_begin_phase(
@@ -655,7 +658,8 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     fn apply_system_phase_{{ phase.name.field }}_without_events(&mut self)
     where
         E: SystemPhaseEvents,
-        Q: WorldCommandSender + WorldCommandReceiver
+        Q: WorldCommandSender + WorldCommandReceiver,
+        Self: WorldUserCommandHandler<UserCommand = <Q as WorldUserCommand>::UserCommand>,
     {
         {%- if world.scheduled_systems[phase.name] | length == 0 %}
         // no systems in this phase
@@ -888,7 +892,8 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     fn par_apply_system_phase_{{ phase.name.field }}(&mut self)
     where
         E: SystemPhaseEvents,
-        Q: WorldCommandSender + WorldCommandReceiver
+        Q: WorldCommandSender + WorldCommandReceiver,
+        Self: WorldUserCommandHandler<UserCommand = <Q as WorldUserCommand>::UserCommand>,
     {
         self.on_begin_{{ phase.name.field }}_phase();
         let result = System{{ phase.name.type }}Events::on_begin_phase(
@@ -1181,7 +1186,8 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
     /// Handles all queued commands.
     fn handle_commands(&mut self)
     where
-        Q: WorldCommandReceiver
+        Q: WorldCommandReceiver,
+        Self: WorldUserCommandHandler<UserCommand = <Q as WorldUserCommand>::UserCommand>,
     {
         loop {
             match self.command_queue.recv() {

--- a/crates/sillyecs-build/tests/build.rs
+++ b/crates/sillyecs-build/tests/build.rs
@@ -7,3 +7,49 @@ fn it_works() {
     let reader = BufReader::new(file.as_bytes());
     EcsCode::generate(reader).expect("Failed to build ECS");
 }
+
+/// Regression for the codegen bug where a `SystemPhase` `states:` entry that omits any of the
+/// per-lifecycle access hooks caused the templates to emit
+/// `todo!("Invalid state use in ECS construction"),` in parameter lists, producing invalid Rust.
+/// `SystemPhase::finish` now fills missing hooks from `default`, mirroring `System`.
+#[test]
+fn phase_state_with_partial_hooks_does_not_emit_invalid_rust() {
+    const YAML: &str = r#"
+states:
+  - name: Renderer
+components:
+  - name: Position
+archetypes:
+  - name: Particle
+    components: [Position]
+worlds:
+  - name: Main
+    archetypes: [Particle]
+phases:
+  - name: Render
+    manual: true
+    states:
+      - use: Renderer
+        default: write   # all per-hook accesses default to write; none are spelled out
+systems:
+  - name: Move
+    phase: Render
+    outputs: [Position]
+"#;
+
+    let reader = BufReader::new(YAML.as_bytes());
+    let code = EcsCode::generate(reader).expect("Failed to build ECS");
+
+    for (name, snippet) in [
+        ("components", &code.components),
+        ("archetypes", &code.archetypes),
+        ("systems", &code.systems),
+        ("world", &code.world),
+    ] {
+        assert!(
+            !snippet.contains("Invalid state use in ECS construction"),
+            "{name} output contained the unreachable `todo!` arm, which means a phase-state \
+             hook was left unset at codegen time"
+        );
+    }
+}

--- a/crates/sillyecs/src/lib.rs
+++ b/crates/sillyecs/src/lib.rs
@@ -1,6 +1,5 @@
 //! # Utility functions for `sillyecs`.
 
-mod archetypes;
 mod entity_id;
 mod flatten_copy_slices;
 mod flatten_slices;


### PR DESCRIPTION
## Summary

A pile of latent codegen bugs in the archetype, system, and world templates,
plus a README feature section that summarizes what `sillyecs` actually offers.
Validated end-to-end against a private downstream consumer (build, type-check,
and test pass).

## Fixes

- **#21** `par_apply_system_phases` dispatched the serial `apply_system_phase_X`
  variants, so the per-phase Rayon implementations were unreachable from the
  parallel toplevel entry point. Each phase dispatch now points at the
  matching `par_apply_system_phase_X`.
- **#22** `get_*_component_at`, `get_*_component_at_mut`, `get_entity_at`, and
  `get_entity_at_mut` compared the index against `self.len()` with `>` instead
  of `>=`. Passing `index == self.len()` panicked on the safe path and read
  one-past-the-end on the unchecked path. All four spots now use `>=`.
- **#23** The safe (`allow_unsafe: false`) accessor body referenced an
  undefined `component_name.fields` variable instead of `component.fields`.
  Latent until consumers opted out of the unchecked path.
- **#24** `EcsCode::generate` no longer dumps the components and archetypes
  templates to stdout on every build.
- **#26** The generated `promote_to_X` helpers carry an explanatory
  `note = "…"` on `#[deprecated]` instead of warning silently.
- **#36** `SystemPhase` states reached the templates with `None` lifecycle
  hooks whenever a YAML entry only spelled out `default:` (or used an unknown
  shorthand). Serde rendered those as JSON `null`, and the templates'
  `default(value="none")` filter did not catch null, dropping into the
  `todo!("Invalid state use in ECS construction"),` else arm inside parameter
  lists and producing Rust that did not parse. `System` already filled
  missing hooks via `apply_state_defaults`; hoist that logic to
  `StateUse::apply_defaults` and call it from `SystemPhase::finish` so phase
  events get the same treatment. Regression test covers the case.
- **#37** `handle_user_command` carried the
  `Self: WorldUserCommandHandler<UserCommand = <Q as WorldUserCommand>::UserCommand>`
  bound, but every function up the call chain — `handle_commands` and the six
  `apply_system_phase*` / `par_apply_system_phase*` / `*_without_events`
  variants — only declared `Q: WorldCommandSender + WorldCommandReceiver`.
  That let the templates render fine but made every downstream consumer fail
  to compile with `type mismatch resolving Q::UserCommand == ...` as soon as
  it wired up a real command queue. Propagated the bound through the chain.

## Docs

- README gets a Features section summarizing compile-time codegen, SoA
  archetype storage, automatic scheduling with sequential and Rayon-parallel
  variants, phase lifecycle, fine-grained state access, deferred world
  commands, frontload helpers, pluggable `EntityLocationMap`, and the
  optional unchecked accessors.
- `.gitignore` reserves `.retro/` for a local checkout of a private downstream
  consumer used to validate template changes end-to-end. Must never be
  committed.

## Test plan

- `cargo test --workspace` — all sillyecs unit and integration tests pass,
  including the new `phase_state_with_partial_hooks_does_not_emit_invalid_rust`
  regression for #36.
- Private downstream consumer (`retro`) was migrated to current sillyecs via
  this branch and exercises every fix above: `cargo build --workspace` and
  `cargo test --workspace` both pass (19/19 tests). The fixes in #36 and #37
  were originally surfaced by that integration check.

Closes #21
Closes #22
Closes #23
Closes #24
Closes #26
Closes #36
Closes #37