### PR TITLE
Reject cross-phase run_after edges at build time

### DIFF
--- a/crates/sillyecs-build/src/ecs.rs
+++ b/crates/sillyecs-build/src/ecs.rs
@@ -98,6 +98,15 @@ pub enum EcsError {
     #[error("System {1} depends on undefined system {0}.")]
     MissingSystemDependency(String, String),
     #[error(
+        "System {system} (phase '{system_phase}') has a run_after dependency on system {dependency} in phase '{dependency_phase}'. Cross-phase run_after edges have no effect; inter-phase ordering is enforced by phase order itself. Remove the dependency or move both systems into the same phase."
+    )]
+    CrossPhaseRunAfter {
+        system: String,
+        system_phase: String,
+        dependency: String,
+        dependency_phase: String,
+    },
+    #[error(
         "A cycle was detected in the system run order (run_after edges): System {0} depends on itself."
     )]
     SystemDependsOnItself(String),
@@ -238,23 +247,35 @@ impl Ecs {
     }
 
     pub(crate) fn ensure_system_consistency(&mut self) -> Result<(), EcsError> {
+        let system_phases: HashMap<_, _> =
+            self.systems.iter().map(|s| (&s.name, &s.phase)).collect();
+
         for system in &self.systems {
             let required_components: HashSet<_> =
                 system.inputs.iter().chain(&system.outputs).collect();
 
             // Ensure all `run_after` dependencies exist in self.systems
             for dependency in &system.run_after {
-                if !self.systems.iter().any(|s| s.name == *dependency) {
+                let Some(dep_phase) = system_phases.get(dependency) else {
                     return Err(EcsError::MissingSystemDependency(
                         dependency.type_name_raw.clone(),
                         system.name.type_name.clone(),
                     ));
-                }
+                };
 
                 if dependency == &system.name {
                     return Err(EcsError::SystemDependsOnItself(
                         system.name.type_name.clone(),
                     ));
+                }
+
+                if *dep_phase != &system.phase {
+                    return Err(EcsError::CrossPhaseRunAfter {
+                        system: system.name.type_name.clone(),
+                        system_phase: system.phase.type_name_raw.clone(),
+                        dependency: dependency.type_name_raw.clone(),
+                        dependency_phase: dep_phase.type_name_raw.clone(),
+                    });
                 }
             }
 

--- a/crates/sillyecs-build/src/lib.rs
+++ b/crates/sillyecs-build/src/lib.rs
@@ -10,6 +10,7 @@ mod system_scheduler;
 mod world;
 
 pub use crate::code::EcsCode;
+pub use crate::ecs::EcsError;
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
 

--- a/crates/sillyecs-build/tests/build.rs
+++ b/crates/sillyecs-build/tests/build.rs
@@ -1,4 +1,4 @@
-use sillyecs_build::EcsCode;
+use sillyecs_build::{EcsCode, EcsError};
 use std::io::BufReader;
 
 #[test]
@@ -51,5 +51,54 @@ systems:
             "{name} output contained the unreachable `todo!` arm, which means a phase-state \
              hook was left unset at codegen time"
         );
+    }
+}
+
+/// Regression for issue #28: a `run_after` edge that points at a system in a different phase
+/// used to pass validation silently and then be dropped by the per-phase scheduler. It must be
+/// rejected at build time so the misconfiguration is visible to the user.
+#[test]
+fn cross_phase_run_after_is_rejected() {
+    const YAML: &str = r#"
+components:
+  - name: Position
+archetypes:
+  - name: Particle
+    components: [Position]
+worlds:
+  - name: Main
+    archetypes: [Particle]
+phases:
+  - name: Update
+  - name: Render
+    manual: true
+systems:
+  - name: Tick
+    phase: Update
+    outputs: [Position]
+  - name: Draw
+    phase: Render
+    run_after: [Tick]
+    inputs: [Position]
+"#;
+
+    let reader = BufReader::new(YAML.as_bytes());
+    let err = match EcsCode::generate(reader) {
+        Ok(_) => panic!("cross-phase run_after must fail"),
+        Err(e) => e,
+    };
+    match err {
+        EcsError::CrossPhaseRunAfter {
+            system,
+            system_phase,
+            dependency,
+            dependency_phase,
+        } => {
+            assert_eq!(system, "DrawSystem");
+            assert_eq!(system_phase, "Render");
+            assert_eq!(dependency, "Tick");
+            assert_eq!(dependency_phase, "Update");
+        }
+        other => panic!("expected CrossPhaseRunAfter, got {other:?}"),
     }
 }


### PR DESCRIPTION
## Summary
- `schedule_systems` is invoked per phase with only same-phase systems, so a `run_after:` edge pointing at a system in a different phase passed existence validation and was then silently dropped. Users wrote `run_after: [Physics]` on a `Render` system, got no error, no warning, no enforcement.
- `Ecs::ensure_system_consistency` now builds a `system -> phase` map and rejects mismatched edges with the new `EcsError::CrossPhaseRunAfter { system, system_phase, dependency, dependency_phase }` variant. Inter-phase ordering is already enforced by phase order itself.
- `EcsError` is re-exported from the crate root so downstream consumers (and the new test) can pattern-match on variants.

Closes #28.

## Test plan
- [x] `cargo test -p sillyecs-build` (new `cross_phase_run_after_is_rejected` regression test + existing `it_works` and `phase_state_with_partial_hooks_does_not_emit_invalid_rust`).
- [x] `cargo test --workspace`.