### PR TITLE
Drop per-tick Box allocation in lookup preflight/postflight

### DIFF
--- a/crates/sillyecs-build/templates/systems.rs.jinja2
+++ b/crates/sillyecs-build/templates/systems.rs.jinja2
@@ -433,7 +433,7 @@ pub trait Apply{{ system.name.type }}: System {
         context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- if (system.lookup | count) > 0 %}
-        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        lookup: &dyn {{system.name.raw}}ComponentLookup,
         {%- endif -%}
         {%- for state in system.states %}
             {%- set access = state.preflight | default(value="none") %}
@@ -482,7 +482,7 @@ pub trait Apply{{ system.name.type }}: System {
         context: &::sillyecs::FrameContext,
         {%- endif %}
         {%- if (system.lookup | count) > 0 %}
-        lookup: Box<&dyn {{system.name.raw}}ComponentLookup>,
+        lookup: &dyn {{system.name.raw}}ComponentLookup,
         {%- endif -%}
         {%- for state in system.states %}
             {%- set access = state.postflight | default(value="none") %}

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -715,7 +715,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                     &self.context,
                     {%- endif %}
                     {%- if (system.lookup | count) > 0 %}
-                    Box::new(&self.archetypes),
+                    &self.archetypes,
                     {%- endif -%}
                     {%- for state in system.states %}
                         {%- set access = state.preflight | default(value="none") %}
@@ -814,7 +814,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                     &self.context,
                     {%- endif %}
                     {%- if (system.lookup | count) > 0 %}
-                    Box::new(&self.archetypes),
+                    &self.archetypes,
                     {%- endif -%}
                     {%- for state in system.states %}
                         {%- set access = state.postflight | default(value="none") %}
@@ -982,7 +982,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                                 &self.context,
                                 {%- endif %}
                                 {%- if (system.lookup | count) > 0 %}
-                                Box::new(&self.archetypes),
+                                &self.archetypes,
                                 {%- endif -%}
                                 {%- for state in system.states %}
                                     {%- set access = state.preflight | default(value="none") %}
@@ -1081,7 +1081,7 @@ impl<E, Q> {{ world.name.type }}<E, Q> {
                                 &self.context,
                                 {%- endif %}
                                 {%- if (system.lookup | count) > 0 %}
-                                Box::new(&self.archetypes),
+                                &self.archetypes,
                                 {%- endif -%}
                                 {%- for state in system.states %}
                                     {%- set access = state.postflight | default(value="none") %}

--- a/crates/sillyecs-build/tests/build.rs
+++ b/crates/sillyecs-build/tests/build.rs
@@ -54,6 +54,54 @@ systems:
     }
 }
 
+/// Regression for issue #27: per-tick `Box::new(&self.archetypes)` heap allocation was emitted in
+/// preflight/postflight call sites of systems with `lookup:` entries. The trait method now takes
+/// `&dyn XComponentLookup` directly and the call sites pass `&self.archetypes` without boxing.
+#[test]
+fn lookup_methods_take_bare_reference_not_box() {
+    const YAML: &str = r#"
+components:
+  - name: Position
+  - name: Velocity
+archetypes:
+  - name: Particle
+    components: [Position, Velocity]
+worlds:
+  - name: Main
+    archetypes: [Particle]
+phases:
+  - name: Update
+systems:
+  - name: Move
+    phase: Update
+    inputs: [Velocity]
+    outputs: [Position]
+    lookup: [Position]
+    preflight: true
+    postflight: true
+"#;
+
+    let reader = BufReader::new(YAML.as_bytes());
+    let code = EcsCode::generate(reader).expect("Failed to build ECS");
+
+    assert!(
+        !code.systems.contains("Box<&dyn"),
+        "trait method must not wrap lookup reference in Box"
+    );
+    assert!(
+        !code.world.contains("Box::new(&self.archetypes)"),
+        "preflight/postflight call sites must not allocate a Box around &self.archetypes"
+    );
+    assert!(
+        code.systems.contains("&dyn MoveComponentLookup"),
+        "trait method should accept &dyn MoveComponentLookup directly"
+    );
+    assert!(
+        code.world.contains("&self.archetypes,"),
+        "preflight/postflight call sites should pass &self.archetypes directly"
+    );
+}
+
 /// Regression for issue #28: a `run_after` edge that points at a system in a different phase
 /// used to pass validation silently and then be dropped by the per-phase scheduler. It must be
 /// rejected at build time so the misconfiguration is visible to the user.


### PR DESCRIPTION
## Summary
- Trait method for systems with `lookup:` entries now takes `lookup: &dyn XComponentLookup` instead of `Box<&dyn XComponentLookup>`. The `Box` around a borrowed reference served no ownership purpose and added a double indirection.
- All four preflight/postflight call sites in `world.rs.jinja2` (serial + parallel paths) now pass `&self.archetypes` directly instead of `Box::new(&self.archetypes)`. That removes one heap allocation per archetype per phase tick on the hot path.
- Adds a regression test (`lookup_methods_take_bare_reference_not_box`) that builds a small ECS with a system declaring `lookup`, `preflight`, and `postflight`, then asserts the generated code contains neither `Box<&dyn` (trait sig) nor `Box::new(&self.archetypes` (call sites), and that the trait sig uses `&dyn MoveComponentLookup` directly.

Fixes #27.

## Test plan
- [x] `cargo test --workspace` (incl. new regression test)
- [x] Downstream `.retro` consumer rebuilds clean (`cargo check --workspace`)