### PR TITLE
Silence on-by-default lints in generated code

### DIFF
--- a/crates/sillyecs-build/templates/archetypes.rs.jinja2
+++ b/crates/sillyecs-build/templates/archetypes.rs.jinja2
@@ -188,6 +188,7 @@ pub struct EntityWithIdAndData<Data: EntityData> {
 
 /// Marker trait for entity data.
 pub trait EntityData {
+    #[allow(dead_code)]
     const ARCHETYPE_ID: ArchetypeId;
 }
 
@@ -310,7 +311,7 @@ impl {{ archetype.name.type }} {
     /// Iterates all entities in this archetype.
     #[inline]
     #[allow(dead_code)]
-    pub fn iter(&self) -> {{ archetype.name.raw }}EntityIterator {
+    pub fn iter(&self) -> {{ archetype.name.raw }}EntityIterator<'_> {
         {{ archetype.name.raw }}EntityIterator::new(self)
     }
     {%- for component in archetype.components %}
@@ -363,7 +364,7 @@ impl {{ archetype.name.type }} {
 
     /// Gets the entity at the specified index.
     #[allow(dead_code)]
-    pub fn get_entity_at(&self, index: usize) -> Option<{{ archetype.name.raw }}EntityRef> {
+    pub fn get_entity_at(&self, index: usize) -> Option<{{ archetype.name.raw }}EntityRef<'_>> {
         if index >= self.len() {
             return None;
         }
@@ -382,7 +383,7 @@ impl {{ archetype.name.type }} {
 
     /// Mutably gets the entity at the specified index.
     #[allow(dead_code)]
-    pub fn get_entity_at_mut(&mut self, index: usize) -> Option<{{ archetype.name.raw }}EntityMut> {
+    pub fn get_entity_at_mut(&mut self, index: usize) -> Option<{{ archetype.name.raw }}EntityMut<'_>> {
         if index >= self.len() {
             return None;
         }
@@ -401,7 +402,7 @@ impl {{ archetype.name.type }} {
 
     /// Gets the entity at the specified index.
     #[allow(dead_code)]
-    pub unsafe fn get_entity_at_unchecked(&self, index: usize) -> {{ archetype.name.raw }}EntityRef {
+    pub unsafe fn get_entity_at_unchecked(&self, index: usize) -> {{ archetype.name.raw }}EntityRef<'_> {
         {{ archetype.name.raw }}EntityRef {
             entity_id: *self.entities.get_unchecked(index),
             {%- for component_name in archetype.components %}
@@ -412,7 +413,7 @@ impl {{ archetype.name.type }} {
 
     /// Gets the entity at the specified index.
     #[allow(dead_code)]
-    pub unsafe fn get_entity_at_unchecked_mut(&mut self, index: usize) -> {{ archetype.name.raw }}EntityMut {
+    pub unsafe fn get_entity_at_unchecked_mut(&mut self, index: usize) -> {{ archetype.name.raw }}EntityMut<'_> {
         {{ archetype.name.raw }}EntityMut {
             entity_id: *self.entities.get_unchecked(index),
             {%- for component_name in archetype.components %}

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -1450,7 +1450,7 @@ pub trait EntityAccess {
     fn get_{{ archetype.name.field }}_entity(
         &self,
         entity_id: ::sillyecs::EntityId
-    ) -> Option<{{ archetype.name.raw }}EntityRef>
+    ) -> Option<{{ archetype.name.raw }}EntityRef<'_>>
     {
         None
     }
@@ -1466,7 +1466,7 @@ pub trait EntityAccessMut: EntityAccess {
     fn get_{{ archetype.name.field }}_entity_mut(
         &mut self,
         entity_id: ::sillyecs::EntityId
-    ) -> Option<{{ archetype.name.raw }}EntityMut>
+    ) -> Option<{{ archetype.name.raw }}EntityMut<'_>>
     {
         None
     }
@@ -1484,7 +1484,7 @@ impl<E, Q> EntityAccess for {{ world.name.type }}<E, Q> {
     fn get_{{ archetype.name.field }}_entity(
         &self,
         entity_id: ::sillyecs::EntityId
-    ) -> Option<{{ archetype.name.raw }}EntityRef>
+    ) -> Option<{{ archetype.name.raw }}EntityRef<'_>>
     {
         EntityAccess::get_{{ archetype.name.field }}_entity(&self.archetypes, entity_id)
     }
@@ -1503,7 +1503,7 @@ impl<E, Q> EntityAccessMut for {{ world.name.type }}<E, Q> {
     fn get_{{ archetype.name.field }}_entity_mut(
         &mut self,
         entity_id: ::sillyecs::EntityId
-    ) -> Option<{{ archetype.name.raw }}EntityMut>
+    ) -> Option<{{ archetype.name.raw }}EntityMut<'_>>
     {
         EntityAccessMut::get_{{ archetype.name.field }}_entity_mut(&mut self.archetypes, entity_id)
     }
@@ -1551,7 +1551,7 @@ impl EntityAccess for {{ world.name.type }}Archetypes {
     fn get_{{ archetype.name.field }}_entity(
         &self,
         entity_id: ::sillyecs::EntityId
-    ) -> Option<{{ archetype.name.raw }}EntityRef>
+    ) -> Option<{{ archetype.name.raw }}EntityRef<'_>>
     {
         let ear = self.entity_locations.get(&entity_id)?.clone();
         if ear.archetype != {{ archetype.name.type }}::ID {
@@ -1575,7 +1575,7 @@ impl EntityAccessMut for {{ world.name.type }}Archetypes {
     fn get_{{ archetype.name.field }}_entity_mut(
         &mut self,
         entity_id: ::sillyecs::EntityId
-    ) -> Option<{{ archetype.name.raw }}EntityMut>
+    ) -> Option<{{ archetype.name.raw }}EntityMut<'_>>
     {
         let ear = self.entity_locations.get(&entity_id)?.clone();
         if ear.archetype != {{ archetype.name.type }}::ID {


### PR DESCRIPTION
## Summary
Generated code triggered on-by-default lints in downstream consumer crates. This PR adjusts the templates so the emitted code is warning-free in 2024-edition crates.

- **`mismatched_lifetime_syntaxes` (Rust 2024)** on accessor methods that returned `EntityRef` / `EntityMut` / `EntityIterator` with the lifetime elided in the return position while binding it from `&self`. All such return positions now use `<'_>`. Affected templates: `archetypes.rs.jinja2` (`get_entity_at`, `get_entity_at_mut`, `get_entity_at_unchecked`, `get_entity_at_unchecked_mut`, `iter`), `world.rs.jinja2` (`get_*_entity` / `get_*_entity_mut` across the `EntityAccess` / `EntityAccessMut` trait, world `impl`s, and the `WorldArchetypes` `impl`s).
- **`dead_code`** on the public marker trait constant `EntityData::ARCHETYPE_ID`, which is part of the generated public surface and may be unused inside any individual downstream crate. Annotated with `#[allow(dead_code)]`.

## Verification
- `cargo test --workspace` in sillyecs: all build tests pass (unchanged set).
- Downstream `.retro` consumer (uses 2024 edition with default lints): `cargo build --workspace` warning count dropped from 133 to 33, and `grep -c "generated/"` over the build output is now `0` (the remaining 33 warnings are all in user code, not generated code).

## Test plan
- [x] `cargo test --workspace`
- [x] Downstream rebuild reports no warnings inside `generated/`