### PR TITLE
Make ECS ID assignment deterministic and per-Ecs

### DIFF
--- a/crates/sillyecs-build/src/archetype.rs
+++ b/crates/sillyecs-build/src/archetype.rs
@@ -1,10 +1,7 @@
 use crate::Name;
 use crate::component::{Component, ComponentId, ComponentRef};
 use core::ops::Deref;
-use core::sync::atomic::AtomicU64;
 use serde::{Deserialize, Deserializer, Serialize};
-
-static ARCHETYPE_IDS: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Archetype {
@@ -83,15 +80,9 @@ impl Archetype {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
-pub struct ArchetypeId(u64);
-
-impl Default for ArchetypeId {
-    fn default() -> Self {
-        Self(ARCHETYPE_IDS.fetch_add(1, core::sync::atomic::Ordering::SeqCst))
-    }
-}
+pub struct ArchetypeId(pub(crate) u64);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]

--- a/crates/sillyecs-build/src/component.rs
+++ b/crates/sillyecs-build/src/component.rs
@@ -3,9 +3,6 @@ use crate::archetype::{Archetype, ArchetypeId, ArchetypeRef};
 use crate::system::{System, SystemId, SystemName};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::ops::Deref;
-use std::sync::atomic::AtomicU64;
-
-static COMPONENT_IDS: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Component {
@@ -38,15 +35,9 @@ pub struct Component {
 
 pub type ComponentRef = ComponentName;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
-pub struct ComponentId(u64);
-
-impl Default for ComponentId {
-    fn default() -> Self {
-        Self(COMPONENT_IDS.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
-    }
-}
+pub struct ComponentId(pub(crate) u64);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]

--- a/crates/sillyecs-build/src/ecs.rs
+++ b/crates/sillyecs-build/src/ecs.rs
@@ -34,7 +34,7 @@ pub struct Ecs {
 
 impl Ecs {
     pub(crate) fn finish(&mut self) -> Result<(), EcsError> {
-        self.assign_ids();
+        self.assign_ids()?;
 
         let cloned_archetypes = self.archetypes.clone();
         for archetype in &mut self.archetypes {
@@ -70,7 +70,16 @@ impl Ecs {
     /// their order of declaration. IDs start at `1` so they remain valid for the
     /// `NonZeroU64`-backed constants the templates emit, and they are a pure function of the
     /// input YAML (no global process-wide counters).
-    fn assign_ids(&mut self) {
+    ///
+    /// `ComponentId`, `ArchetypeId`, and `SystemId` are emitted as `#[repr(u32)]` enum
+    /// discriminants in generated code, so the count for each kind must fit in `u32`. The check
+    /// is done here so a too-large input fails fast with a clear error instead of producing
+    /// invalid Rust that fails to compile with a confusing out-of-range discriminant message.
+    fn assign_ids(&mut self) -> Result<(), EcsError> {
+        check_u32_capacity("components", self.components.len())?;
+        check_u32_capacity("archetypes", self.archetypes.len())?;
+        check_u32_capacity("systems", self.systems.len())?;
+
         for (index, component) in self.components.iter_mut().enumerate() {
             component.id = ComponentId(index as u64 + 1);
         }
@@ -83,7 +92,16 @@ impl Ecs {
         for (index, world) in self.worlds.iter_mut().enumerate() {
             world.id = WorldId(index as u64 + 1);
         }
+
+        Ok(())
     }
+}
+
+fn check_u32_capacity(kind: &'static str, count: usize) -> Result<(), EcsError> {
+    if count > u32::MAX as usize {
+        return Err(EcsError::TooManyIds { kind, count });
+    }
+    Ok(())
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -135,6 +153,11 @@ pub enum EcsError {
     MissingStateInSystem(String, String),
     #[error("State '{0}' is defined multiple times.")]
     StateDefinedMultipleTimes(String),
+    #[error(
+        "Too many {kind}: {count} declared, but generated `#[repr(u32)]` IDs only support up to {max}.",
+        max = u32::MAX
+    )]
+    TooManyIds { kind: &'static str, count: usize },
 }
 
 impl Ecs {

--- a/crates/sillyecs-build/src/ecs.rs
+++ b/crates/sillyecs-build/src/ecs.rs
@@ -1,8 +1,8 @@
-use crate::archetype::Archetype;
-use crate::component::Component;
+use crate::archetype::{Archetype, ArchetypeId};
+use crate::component::{Component, ComponentId};
 use crate::state::State;
-use crate::system::{System, SystemPhase};
-use crate::world::World;
+use crate::system::{System, SystemId, SystemPhase};
+use crate::world::{World, WorldId};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
@@ -34,6 +34,8 @@ pub struct Ecs {
 
 impl Ecs {
     pub(crate) fn finish(&mut self) -> Result<(), EcsError> {
+        self.assign_ids();
+
         let cloned_archetypes = self.archetypes.clone();
         for archetype in &mut self.archetypes {
             archetype.finish(&self.components, &cloned_archetypes);
@@ -62,6 +64,25 @@ impl Ecs {
         }
 
         Ok(())
+    }
+
+    /// Assigns deterministic, per-`Ecs` IDs to components, archetypes, systems, and worlds in
+    /// their order of declaration. IDs start at `1` so they remain valid for the
+    /// `NonZeroU64`-backed constants the templates emit, and they are a pure function of the
+    /// input YAML (no global process-wide counters).
+    fn assign_ids(&mut self) {
+        for (index, component) in self.components.iter_mut().enumerate() {
+            component.id = ComponentId(index as u64 + 1);
+        }
+        for (index, archetype) in self.archetypes.iter_mut().enumerate() {
+            archetype.id = ArchetypeId(index as u64 + 1);
+        }
+        for (index, system) in self.systems.iter_mut().enumerate() {
+            system.id = SystemId(index as u64 + 1);
+        }
+        for (index, world) in self.worlds.iter_mut().enumerate() {
+            world.id = WorldId(index as u64 + 1);
+        }
     }
 }
 

--- a/crates/sillyecs-build/src/system.rs
+++ b/crates/sillyecs-build/src/system.rs
@@ -7,9 +7,6 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
-use std::sync::atomic::AtomicU64;
-
-static SYSTEM_IDS: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -291,15 +288,9 @@ impl System {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct SystemId(pub(crate) u64);
-
-impl Default for SystemId {
-    fn default() -> Self {
-        Self(SYSTEM_IDS.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct SystemPhase {

--- a/crates/sillyecs-build/src/world.rs
+++ b/crates/sillyecs-build/src/world.rs
@@ -7,7 +7,6 @@ use crate::system::{System, SystemPhase, SystemPhaseRef};
 use crate::system_scheduler::schedule_systems;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::hash::Hash;
 use std::ops::Deref;
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/sillyecs-build/src/world.rs
+++ b/crates/sillyecs-build/src/world.rs
@@ -6,12 +6,9 @@ use crate::state::State;
 use crate::system::{System, SystemPhase, SystemPhaseRef};
 use crate::system_scheduler::schedule_systems;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::hash::Hash;
 use std::ops::Deref;
-use std::sync::atomic::AtomicU64;
-
-static WORLD_IDS: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct World {
@@ -29,12 +26,14 @@ pub struct World {
     #[serde(skip_deserializing)]
     pub states: Vec<State>,
 
-    /// The systems in scheduling order (based on this world's systems).
+    /// The systems in scheduling order (based on this world's systems). Ordered by phase name so
+    /// that codegen output is deterministic between runs.
     #[serde(default, skip_deserializing)]
-    pub scheduled_systems: HashMap<SystemPhaseRef, Vec<Vec<System>>>,
-    /// The components used in this world (based on this world's archetypes).
+    pub scheduled_systems: BTreeMap<SystemPhaseRef, Vec<Vec<System>>>,
+    /// The components used in this world (based on this world's archetypes). Ordered by component
+    /// and archetype name so that codegen output is deterministic between runs.
     #[serde(default, skip_deserializing)]
-    pub components: HashMap<ComponentRef, HashSet<ArchetypeRef>>,
+    pub components: BTreeMap<ComponentRef, BTreeSet<ArchetypeRef>>,
 }
 
 impl World {
@@ -59,7 +58,7 @@ impl World {
                     .and_modify(|set| {
                         set.insert(archetype.name.clone());
                     })
-                    .or_insert(HashSet::from([archetype.name.clone()]));
+                    .or_insert(BTreeSet::from([archetype.name.clone()]));
             }
 
             self.archetypes.push(archetype.clone());
@@ -103,7 +102,7 @@ impl World {
     }
 
     pub(crate) fn scheduled_systems(&mut self, phases: &[SystemPhase]) -> Result<(), EcsError> {
-        let mut phase_groups = HashMap::new();
+        let mut phase_groups = BTreeMap::new();
         for phase in phases {
             let systems_in_group: Vec<_> = self
                 .systems
@@ -135,15 +134,9 @@ impl World {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
-pub struct WorldId(u64);
-
-impl Default for WorldId {
-    fn default() -> Self {
-        Self(WORLD_IDS.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
-    }
-}
+pub struct WorldId(pub(crate) u64);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]

--- a/crates/sillyecs-build/tests/build.rs
+++ b/crates/sillyecs-build/tests/build.rs
@@ -54,6 +54,60 @@ systems:
     }
 }
 
+/// Regression for issue #25: previously, `ArchetypeId`, `SystemId`, `WorldId`, and `ComponentId`
+/// were assigned by process-wide `AtomicU64` counters in the build crate, which made successive
+/// `EcsCode::generate` calls in the same process emit *different* numeric IDs for the same input
+/// YAML. IDs are now assigned per-`Ecs` from the deserialization order, so two generations from
+/// the same YAML must produce byte-identical output.
+#[test]
+fn ids_are_deterministic_across_generate_calls() {
+    const YAML: &str = r#"
+components:
+  - name: Position
+  - name: Velocity
+archetypes:
+  - name: Particle
+    components: [Position, Velocity]
+  - name: Static
+    components: [Position]
+worlds:
+  - name: Main
+    archetypes: [Particle, Static]
+  - name: Secondary
+    archetypes: [Particle]
+phases:
+  - name: Update
+systems:
+  - name: Move
+    phase: Update
+    inputs: [Velocity]
+    outputs: [Position]
+  - name: Settle
+    phase: Update
+    inputs: [Position]
+"#;
+
+    let first = EcsCode::generate(BufReader::new(YAML.as_bytes())).expect("first generate");
+    let second = EcsCode::generate(BufReader::new(YAML.as_bytes())).expect("second generate");
+
+    assert_eq!(
+        first.components, second.components,
+        "component IDs / generated component module drifted between generate() calls"
+    );
+    assert_eq!(
+        first.archetypes, second.archetypes,
+        "archetype IDs / generated archetype module drifted between generate() calls"
+    );
+    assert_eq!(
+        first.systems, second.systems,
+        "system IDs / generated system module drifted between generate() calls"
+    );
+    assert_eq!(
+        first.world, second.world,
+        "world IDs / generated world module drifted between generate() calls"
+    );
+}
+
 /// Regression for issue #27: per-tick `Box::new(&self.archetypes)` heap allocation was emitted in
 /// preflight/postflight call sites of systems with `lookup:` entries. The trait method now takes
 /// `&dyn XComponentLookup` directly and the call sites pass `&self.archetypes` without boxing.


### PR DESCRIPTION
## Summary
`ArchetypeId`, `SystemId`, `WorldId`, and `ComponentId` were assigned by process-wide `static AtomicU64` counters in the build crate. Because those values are baked into generated code (as `repr(u32)` enum discriminants and as `_ID_VALUE` `NonZeroU64` constants), a second `EcsCode::generate` call in the same process saw shifted IDs — breaking downstream consumers that hard-code numeric IDs and making it impossible to regression-test the codegen output by comparing two runs of the same YAML.

This PR:
- Deletes the four `static *_IDS: AtomicU64` counters and their `Default` impls.
- Adds `Ecs::assign_ids`, called at the top of `Ecs::finish()`, which walks `components`, `archetypes`, `systems`, and `worlds` in declaration order and assigns sequential 1-based IDs. ID assignment is now a pure function of the input YAML.
- The `Default` impls for the ID types now produce `Self(0)`. Since the templates emit `NonZeroU64::new(<id>).expect(...)`, anything that ever forgot to assign would fail loudly at codegen.
- Switches two pieces of internal world state that participate in codegen output from `HashMap` / `HashSet` to `BTreeMap` / `BTreeSet`:
  - `World::scheduled_systems: BTreeMap<SystemPhaseRef, Vec<Vec<System>>>`
  - `World::components: BTreeMap<ComponentRef, BTreeSet<ArchetypeRef>>`
  These were iterated by the world template; their `HashMap` iteration order would have re-introduced non-determinism in the generated `match` arms otherwise (and was the first thing the new regression test caught).
- Adds a regression test (`ids_are_deterministic_across_generate_calls`) that generates the same YAML twice and asserts that the `components`, `archetypes`, `systems`, and `world` snippets are byte-identical.

Fixes #25.

## Test plan
- [x] `cargo test --workspace` (incl. new regression test)
- [x] Downstream `.retro` consumer rebuilds clean (`cargo build --workspace`); generated-code warning count unchanged.