### PR TITLE
Hoist edition/rust-version to workspace.package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,11 @@
 resolver = "2"
 members = ["crates/*"]
 default-members = ["crates/*"]
+
+[workspace.package]
+edition = "2024"
+rust-version = "1.85"
+license = "EUPL-1.2"
+homepage = "https://github.com/sunsided/sillyecs"
+repository = "https://github.com/sunsided/sillyecs.git"
+authors = ["Markus Mayer <widemeadows@gmail.com>"]

--- a/crates/sillyecs-build/Cargo.toml
+++ b/crates/sillyecs-build/Cargo.toml
@@ -3,12 +3,13 @@ name = "sillyecs-build"
 description = "A silly little compile-time generated archetype ECS in Rust"
 keywords = ["ecs", "archetype", "game-development"]
 categories = ["game-development", "game-engines", "development-tools::build-utils"]
-homepage = "https://github.com/sunsided/sillyecs"
-repository = "https://github.com/sunsided/sillyecs.git"
-authors = ["Markus Mayer <widemeadows@gmail.com>"]
-license = "EUPL-1.2"
 version = "0.0.6"
-edition = "2024"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
 
 [dependencies]
 minijinja = { version = "2.20.0", default-features = false, features = ["builtins", "serde"] }

--- a/crates/sillyecs/Cargo.toml
+++ b/crates/sillyecs/Cargo.toml
@@ -3,12 +3,13 @@ name = "sillyecs"
 description = "A silly little compile-time generated archetype ECS in Rust"
 keywords = ["ecs", "archetype", "game-development"]
 categories = ["game-development", "game-engines"]
-homepage = "https://github.com/sunsided/sillyecs"
-repository = "https://github.com/sunsided/sillyecs.git"
-authors = ["Markus Mayer <widemeadows@gmail.com>"]
-license = "EUPL-1.2"
 version = "0.0.6"
-edition = "2024"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
 
 [dev-dependencies]
 criterion = "0.8.2"


### PR DESCRIPTION
## Summary
Each crate carried its own `edition`, `license`, `repository`, `homepage`, and `authors`, and none of them declared a `rust-version` at all. That makes it easy to drift (one crate bumps to a newer edition while the other lags) and leaves the MSRV implicit.

Adds a `[workspace.package]` block to the root `Cargo.toml` with `edition = "2024"`, `rust-version = "1.85"` (matching the edition 2024 stable cutoff), and the shared `license` / `homepage` / `repository` / `authors` metadata. Both member crates (`sillyecs`, `sillyecs-build`) now pull those fields with `<field>.workspace = true`. Per-crate fields (`name`, `description`, `version`, `keywords`, `categories`) stay local because they may legitimately differ between crates.

`cargo metadata --no-deps` confirms both crates resolve to `edition = "2024"`, `rust_version = "1.85"`.

Fixes #34.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo metadata` reports `edition = 2024` and `rust_version = 1.85` for both crates.