### PR TITLE
Silence remaining clippy lints in generated code

### DIFF
--- a/crates/sillyecs-build/templates/archetypes.rs.jinja2
+++ b/crates/sillyecs-build/templates/archetypes.rs.jinja2
@@ -517,9 +517,17 @@ impl {{ archetype.name.type }} {
     }
 
     /// Dynamically determines whether this archetype has a specific component.
-    pub const fn has_components<Id>(&self, id: ComponentId) -> bool {
+    // `matches!` arm-list is generated from the archetype's component IDs; whether those IDs are
+    // contiguous (and could be expressed as a range pattern) depends on the user's YAML, so
+    // silence the suggestion globally for this generated check.
+    #[allow(clippy::manual_range_patterns)]
+    pub const fn has_components(&self, id: ComponentId) -> bool {
         let id = id.as_u64();
-        {% for id in archetype.component_ids %}id == {{ id }} || {% endfor %}false
+        {% if archetype.component_ids -%}
+        matches!(id, {% for id in archetype.component_ids %}{{ id }}{% if not loop.last %} | {% endif %}{% endfor %})
+        {%- else -%}
+        false
+        {%- endif %}
     }
 
     /// Spawn a new entity into the world. Must be called through the world for proper bookkeeping.

--- a/crates/sillyecs-build/templates/systems.rs.jinja2
+++ b/crates/sillyecs-build/templates/systems.rs.jinja2
@@ -126,6 +126,10 @@ impl SystemPhase {
     {%- if phase.fixed %}
 
     /// The number of seconds the [`{{ phase.name.raw }}`](SystemPhase::{{ phase.name.raw }}) fixed-time step should run.
+    // `fixed_secs` is computed as `1.0 / hertz` in `f32` precision, but serializing through
+    // `minijinja` widens it to `f64`, so the rendered literal carries more digits than `f32`
+    // can represent. Truncation back to `f32` is the intended behavior.
+    #[allow(clippy::excessive_precision)]
     pub const {{ phase.name.field | upper }}_SECS: f32 = {{ phase.fixed_secs }};
 
     /// The frequency of the [`{{ phase.name.raw }}`](SystemPhase::{{ phase.name.raw }}) fixed-time step.
@@ -600,7 +604,7 @@ pub trait Apply{{ system.name.type }}: System {
         for {{ system.component_untuple_code }} in zipped_iter {
             self.apply_single(
                 {%- if system.needs_context %}
-                &context,
+                context,
                 {%- endif %}
                 {%- for state in system.states %}
                     {%- set access = state.system | default(value="none") %}


### PR DESCRIPTION
## Summary

Follow-up to #42: downstream consumers (e.g. `.retro` on the 2024 edition + current clippy) still saw four on-by-default lint families inside `generated/`. This PR makes the templates emit code that's clean for all of them.

- **`extra_unused_type_parameters`** on `Archetype::has_components<Id>`: the `<Id>` generic was declared but never referenced. Removed the parameter.
- **`nonminimal_bool`** on the trailing `|| false` in the `has_components` body: replaced the chain `id == 1 || id == 2 || ... || false` with `matches!(id, 1 | 2 | ...)`. The `matches!` form also expresses intent more clearly. Whether the archetype's component IDs happen to be contiguous (and thus eligible for an `a..=b` range pattern) depends on the user's YAML, so `#[allow(clippy::manual_range_patterns)]` is added on the function with a comment.
- **`excessive_precision`** on the `*_SECS` phase constants: `fixed_secs` is an `f32` computed as `1.0 / hertz`, but minijinja widens it to `f64` when rendering, producing more digits than `f32` can represent. The truncation back to `f32` is intentional; annotated the const with `#[allow(clippy::excessive_precision)]` plus an inline comment explaining why.
- **`needless_borrow`** on `&context` in the default `apply_many` -> `apply_single` body: `context` is already `&FrameContext`, so prefixing another `&` reborrows pointlessly. Pass `context` directly.

## Outcome

- `cargo test -p sillyecs-build` is green (7 + 7 passing as before, including the new scheduler regression from #48).
- Regenerating `.retro` then running `cargo clippy` reports **zero** warnings inside `generated/` (down from 23 across the four lint families above). Total downstream warning count drops 151 -> 128; the remainder is all user code.

## Test plan

- [x] `cargo test -p sillyecs-build`
- [x] Downstream regen + clippy: `grep -c 'generated/' <clippy-output>` is `0`