### PR TITLE
Add integration test that compiles generated code

### DIFF
--- a/crates/sillyecs-build/tests/compile_generated.rs
+++ b/crates/sillyecs-build/tests/compile_generated.rs
@@ -1,8 +1,9 @@
-//! Integration test for issue #39: render generated code into a tempdir crate
-//! and run `cargo check` to make sure the templates produce code that actually
-//! compiles. The existing `build.rs` tests only string-grep the rendered
-//! output, so bugs like #36 (invalid Rust in parameter lists) and #37 (missing
-//! trait bound on `handle_commands`) sneak past them.
+//! Integration test for issue #39: render generated code into a synthetic
+//! fixture crate under the workspace `target/` directory and run `cargo check`
+//! to make sure the templates produce code that actually compiles. The
+//! existing `build.rs` tests only string-grep the rendered output, so bugs
+//! like #36 (invalid Rust in parameter lists) and #37 (missing trait bound on
+//! `handle_commands`) sneak past them.
 //!
 //! Each fixture under `tests/fixtures/<name>/` is a pair of files:
 //! - `ecs.yaml` - the YAML input to `EcsCode::generate`
@@ -10,10 +11,11 @@
 //!   `Apply<X>System` impls, `WorldCommandQueue` impl, `EntityLocationMap`
 //!   alias).
 //!
-//! The test renders the four template outputs into a synthetic library crate
-//! that `include!`s them and the fixture's `user.rs`, then shells out to
-//! `cargo check` against that crate. A non-zero exit prints the captured
-//! stderr and leaks the fixture directory so it can be inspected.
+//! The test renders the four template outputs into the fixture crate at
+//! `target/sillyecs-compile-fixtures/<name>/` (a stable workspace path, not a
+//! system tempdir, so cargo's incremental cache survives across runs), then
+//! shells out to `cargo check` against that crate. A non-zero exit prints the
+//! captured stderr and leaves the fixture directory on disk for inspection.
 
 use sillyecs_build::EcsCode;
 use std::fs;
@@ -55,8 +57,13 @@ fn run_fixture(fixture_name: &str) {
     let src_dir = crate_dir.join("src");
     let generated_dir = src_dir.join("generated");
 
+    // Wipe the fixture crate before writing it. Silently ignoring a failed
+    // deletion would let stale files from a previous run survive into the
+    // next `cargo check`, which could mask a regression by compiling the old
+    // state. Propagate the error so the test fails loudly instead.
     if crate_dir.exists() {
-        let _ = fs::remove_dir_all(&crate_dir);
+        fs::remove_dir_all(&crate_dir)
+            .unwrap_or_else(|e| panic!("clear fixture dir {}: {e}", crate_dir.display()));
     }
     fs::create_dir_all(&generated_dir).expect("create fixture crate dir");
 

--- a/crates/sillyecs-build/tests/compile_generated.rs
+++ b/crates/sillyecs-build/tests/compile_generated.rs
@@ -1,0 +1,144 @@
+//! Integration test for issue #39: render generated code into a tempdir crate
+//! and run `cargo check` to make sure the templates produce code that actually
+//! compiles. The existing `build.rs` tests only string-grep the rendered
+//! output, so bugs like #36 (invalid Rust in parameter lists) and #37 (missing
+//! trait bound on `handle_commands`) sneak past them.
+//!
+//! Each fixture under `tests/fixtures/<name>/` is a pair of files:
+//! - `ecs.yaml` - the YAML input to `EcsCode::generate`
+//! - `user.rs`  - hand-written user-side stubs (component data, system data,
+//!   `Apply<X>System` impls, `WorldCommandQueue` impl, `EntityLocationMap`
+//!   alias).
+//!
+//! The test renders the four template outputs into a synthetic library crate
+//! that `include!`s them and the fixture's `user.rs`, then shells out to
+//! `cargo check` against that crate. A non-zero exit prints the captured
+//! stderr and leaks the fixture directory so it can be inspected.
+
+use sillyecs_build::EcsCode;
+use std::fs;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const FIXTURE_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+/// Path to the `sillyecs` runtime crate, used as a `path =` dependency from the
+/// generated fixture crate. Resolves at compile time against this test crate's
+/// manifest dir so the test works no matter where `cargo` is invoked from.
+const SILLYECS_RUNTIME_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../sillyecs");
+
+#[test]
+fn full_coverage_fixture_compiles() {
+    run_fixture("full_coverage");
+}
+
+fn run_fixture(fixture_name: &str) {
+    let fixture_dir = PathBuf::from(FIXTURE_ROOT).join(fixture_name);
+    let yaml_path = fixture_dir.join("ecs.yaml");
+    let user_path = fixture_dir.join("user.rs");
+
+    let yaml = fs::read(&yaml_path).unwrap_or_else(|e| panic!("read {}: {e}", yaml_path.display()));
+    let user_rs = fs::read_to_string(&user_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", user_path.display()));
+
+    let code = EcsCode::generate(BufReader::new(&yaml[..]))
+        .unwrap_or_else(|e| panic!("EcsCode::generate failed for {fixture_name}: {e:?}"));
+
+    // Stable, per-fixture workspace location so cargo's incremental cache
+    // survives across test runs. Cleaned and rewritten every invocation so
+    // stale state from an earlier failure can't poison a fresh run.
+    let workspace_target = workspace_target_dir();
+    let crate_dir = workspace_target
+        .join("sillyecs-compile-fixtures")
+        .join(fixture_name);
+    let src_dir = crate_dir.join("src");
+    let generated_dir = src_dir.join("generated");
+
+    if crate_dir.exists() {
+        let _ = fs::remove_dir_all(&crate_dir);
+    }
+    fs::create_dir_all(&generated_dir).expect("create fixture crate dir");
+
+    fs::write(generated_dir.join("components_gen.rs"), &code.components).unwrap();
+    fs::write(generated_dir.join("archetypes_gen.rs"), &code.archetypes).unwrap();
+    fs::write(generated_dir.join("systems_gen.rs"), &code.systems).unwrap();
+    fs::write(generated_dir.join("world_gen.rs"), &code.world).unwrap();
+
+    fs::write(src_dir.join("user.rs"), &user_rs).unwrap();
+    fs::write(src_dir.join("lib.rs"), LIB_RS).unwrap();
+    fs::write(crate_dir.join("Cargo.toml"), cargo_toml(fixture_name)).unwrap();
+
+    let target_dir = workspace_target.join("sillyecs-compile-fixtures-target");
+
+    let output = Command::new(env!("CARGO"))
+        .arg("check")
+        .arg("--quiet")
+        .arg("--manifest-path")
+        .arg(crate_dir.join("Cargo.toml"))
+        .env("CARGO_TARGET_DIR", &target_dir)
+        // Inherit RUSTFLAGS / RUSTC etc. from the parent so the fixture builds
+        // with the same toolchain the test runner is using.
+        .output()
+        .expect("spawn cargo check");
+
+    if !output.status.success() {
+        panic!(
+            "generated code from fixture `{fixture_name}` failed to compile.\n\
+             crate at: {}\n\
+             --- stdout ---\n{}\n--- stderr ---\n{}",
+            crate_dir.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}
+
+fn workspace_target_dir() -> PathBuf {
+    // Match cargo's resolution: $CARGO_TARGET_DIR wins, otherwise the workspace
+    // root's `target/`. The test crate's manifest dir is
+    // `<workspace>/crates/sillyecs-build`, so the workspace root is two levels up.
+    if let Ok(custom) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(custom);
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root above sillyecs-build")
+        .join("target")
+}
+
+fn cargo_toml(fixture_name: &str) -> String {
+    format!(
+        r#"[package]
+name = "sillyecs-compile-fixture-{fixture_name}"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+sillyecs = {{ path = "{path}" }}
+tracing = "0.1"
+rayon = "1"
+
+[workspace]
+"#,
+        fixture_name = fixture_name,
+        path = SILLYECS_RUNTIME_PATH.replace('\\', "/"),
+    )
+}
+
+const LIB_RS: &str = r#"//! Auto-generated fixture crate. See compile_generated.rs in sillyecs-build.
+#![allow(dead_code)]
+#![allow(unused_imports)]
+#![allow(clippy::all)]
+
+include!("generated/components_gen.rs");
+include!("generated/archetypes_gen.rs");
+include!("generated/systems_gen.rs");
+include!("generated/world_gen.rs");
+include!("user.rs");
+"#;

--- a/crates/sillyecs-build/tests/fixtures/full_coverage/ecs.yaml
+++ b/crates/sillyecs-build/tests/fixtures/full_coverage/ecs.yaml
@@ -1,0 +1,72 @@
+# Fixture covers the items called out in issue #39:
+#   - non-trivial command queue with a real `UserCommand` type (see user.rs)
+#   - a phase with partial-hook state-use entries (`Render` phase below)
+#   - at least one archetype with `allow_unsafe: false` (file-level default)
+#   - promotions (Particle -> LivingParticle)
+#   - frontload (generated unconditionally, exercised by archetype shape)
+#   - system with `lookup`
+#   - at least one fixed-step phase (`FixedUpdate`)
+
+allow_unsafe: false
+
+states:
+  - name: Input
+  - name: Renderer
+
+components:
+  - name: Position
+  - name: Velocity
+  - name: Health
+  - name: Sprite
+
+archetypes:
+  - name: Particle
+    components: [Position, Velocity]
+    promotions: [LivingParticle]
+  - name: LivingParticle
+    components: [Position, Velocity, Health]
+  - name: Decoration
+    components: [Position, Sprite]
+
+worlds:
+  - name: Main
+    archetypes: [Particle, LivingParticle, Decoration]
+
+phases:
+  - name: Boot
+    manual: true
+  - name: FixedUpdate
+    fixed: 60Hz
+  - name: Update
+    on_request: true
+  - name: Render
+    manual: true
+    states:
+      # Partial-hook entry: no per-hook fields spelled out. Regression for issue #36.
+      - use: Renderer
+        default: write
+
+systems:
+  - name: Step
+    phase: FixedUpdate
+    context: true
+    inputs: [Velocity]
+    outputs: [Position]
+    lookup: [Position]
+    preflight: true
+    postflight: true
+
+  - name: Heal
+    phase: Update
+    commands: true
+    states:
+      - use: Input
+    outputs: [Health]
+
+  - name: Draw
+    phase: Render
+    entities: true
+    inputs: [Position, Sprite]
+    states:
+      - use: Renderer
+        system: write

--- a/crates/sillyecs-build/tests/fixtures/full_coverage/user.rs
+++ b/crates/sillyecs-build/tests/fixtures/full_coverage/user.rs
@@ -1,0 +1,229 @@
+// Hand-written user-side stubs for the `full_coverage` compile fixture. Pairs
+// with `ecs.yaml` in this directory; included from the synthetic library crate
+// built by `tests/compile_generated.rs`.
+
+use std::collections::{HashMap, VecDeque};
+use std::convert::Infallible;
+use std::sync::Mutex;
+
+// The world templates require the consumer to provide an `EntityLocationMap`
+// type alias (see the comment in `world.rs.jinja2`).
+pub type EntityLocationMap<K, V> = HashMap<K, V>;
+
+// --- Component data structs ----------------------------------------------------
+//
+// The component template emits `pub struct XComponent(XData);` and impls
+// `Deref<Target = XData>` etc., so each component named in the YAML needs a
+// matching `XData` type that derives `Debug + Clone + Default`.
+
+#[derive(Debug, Default, Clone)]
+pub struct PositionData {
+    pub x: f32,
+    pub y: f32,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct VelocityData {
+    pub x: f32,
+    pub y: f32,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct HealthData(pub i32);
+
+#[derive(Debug, Default, Clone)]
+pub struct SpriteData(pub u32);
+
+// --- States -------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+pub struct InputState;
+
+#[derive(Debug, Default)]
+pub struct RendererState;
+
+// --- System data + Default for system newtypes --------------------------------
+
+#[derive(Debug, Default)]
+pub struct StepSystemData;
+
+#[derive(Debug, Default)]
+pub struct HealSystemData;
+
+#[derive(Debug, Default)]
+pub struct DrawSystemData;
+
+impl Default for StepSystem {
+    fn default() -> Self {
+        Self(StepSystemData)
+    }
+}
+
+impl Default for HealSystem {
+    fn default() -> Self {
+        Self(HealSystemData)
+    }
+}
+
+impl Default for DrawSystem {
+    fn default() -> Self {
+        Self(DrawSystemData)
+    }
+}
+
+// --- System factory + CreateSystem impls --------------------------------------
+
+pub struct SystemFactory;
+
+impl CreateSystem<StepSystem> for SystemFactory {
+    fn create(&self) -> StepSystem {
+        StepSystem::default()
+    }
+}
+
+impl CreateSystem<HealSystem> for SystemFactory {
+    fn create(&self) -> HealSystem {
+        HealSystem::default()
+    }
+}
+
+impl CreateSystem<DrawSystem> for SystemFactory {
+    fn create(&self) -> DrawSystem {
+        DrawSystem::default()
+    }
+}
+
+// --- Apply<X>System impls -----------------------------------------------------
+//
+// The Apply traits provide defaults for every method, so the minimum a real
+// consumer must spell out is `type Error`. That's what we do here.
+
+impl ApplyStepSystem for StepSystem {
+    type Error = Infallible;
+
+    fn preflight(
+        &mut self,
+        _context: &::sillyecs::FrameContext,
+        _lookup: &dyn StepComponentLookup,
+        _velocities: &[VelocityComponent],
+        _positions: &[PositionComponent],
+    ) {
+    }
+
+    fn postflight(
+        &mut self,
+        _context: &::sillyecs::FrameContext,
+        _lookup: &dyn StepComponentLookup,
+        _velocities: &[VelocityComponent],
+        _positions: &[PositionComponent],
+    ) {
+    }
+}
+
+impl ApplyHealSystem for HealSystem {
+    type Error = Infallible;
+}
+
+impl ApplyDrawSystem for DrawSystem {
+    type Error = Infallible;
+}
+
+// --- User command + queue -----------------------------------------------------
+//
+// Issue #39 explicitly calls for a non-trivial `WorldCommandQueue` with a real
+// `UserCommand` enum. PR #37 / issue #37 were exactly the class of bug that
+// surfaces only when `Q::UserCommand != NoUserCommand`.
+
+#[derive(Debug, Clone)]
+pub enum UserCommand {
+    Heal { amount: i32 },
+    Spawn,
+}
+
+pub struct CommandQueue {
+    queue: Mutex<VecDeque<WorldCommand<UserCommand>>>,
+}
+
+impl CommandQueue {
+    pub fn new() -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+        }
+    }
+}
+
+impl Default for CommandQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+pub struct CommandQueueClosed;
+
+impl std::fmt::Display for CommandQueueClosed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("command queue mutex poisoned")
+    }
+}
+
+impl std::error::Error for CommandQueueClosed {}
+
+impl WorldUserCommand for CommandQueue {
+    type UserCommand = UserCommand;
+}
+
+impl WorldCommandSender for CommandQueue {
+    type Error = CommandQueueClosed;
+
+    fn send(&self, command: WorldCommand<Self::UserCommand>) -> Result<(), Self::Error> {
+        self.queue
+            .lock()
+            .map_err(|_| CommandQueueClosed)?
+            .push_back(command);
+        Ok(())
+    }
+}
+
+impl WorldCommandReceiver for CommandQueue {
+    type Error = CommandQueueClosed;
+
+    fn recv(&self) -> Result<Option<WorldCommand<Self::UserCommand>>, Self::Error> {
+        Ok(self
+            .queue
+            .lock()
+            .map_err(|_| CommandQueueClosed)?
+            .pop_front())
+    }
+}
+
+impl<E, Q> WorldUserCommandHandler for MainWorld<E, Q>
+where
+    Q: WorldUserCommand<UserCommand = UserCommand>,
+{
+    fn handle_user_command(&mut self, command: Self::UserCommand) {
+        // Discard for the fixture; the goal is to compile, not to act.
+        let _ = command;
+    }
+}
+
+// --- Smoke construction -------------------------------------------------------
+//
+// Forces monomorphization of the generic `apply_system_phases*` family with a
+// concrete `Q = CommandQueue` (real `UserCommand`) and `E = NoOpPhaseEvents`.
+// Without an instantiation, some monomorphization-time bugs slip past
+// `cargo check`.
+
+#[allow(dead_code)]
+pub fn smoke() {
+    let factory = SystemFactory;
+    let states = MainWorldStates::default();
+    let queue = CommandQueue::new();
+    let mut world: MainWorld<NoOpPhaseEvents, CommandQueue> =
+        MainWorld::new(&factory, states, queue);
+    world.apply_system_phases();
+    world.par_apply_system_phases();
+    world.apply_system_phase_render();
+    world.par_apply_system_phase_render();
+    world.request_update_phase();
+}


### PR DESCRIPTION
Closes #39.

## Summary

- Adds `crates/sillyecs-build/tests/compile_generated.rs`, an integration test that renders each `tests/fixtures/<name>/` pair through `EcsCode::generate` into a synthetic library crate and runs `cargo check` against it. Failures dump the captured stderr and leave the generated crate on disk for inspection.
- Drops in the first fixture, `full_coverage`, with a hand-written `user.rs` that pins the user-side surface (component data, system data, `Apply<X>System` impls, `WorldCommandQueue` impl over a real `UserCommand` enum, `EntityLocationMap` alias). The fixture YAML exercises the items #39 calls out: non-trivial command queue + `UserCommand`, partial-hook phase state, `allow_unsafe: false`, archetype promotions, system `lookup`, fixed-step phase, and an `on_request` phase.

## Why

The existing `tests/build.rs` cases only render the templates and string-grep the output. That has missed several bugs whose output parsed fine but failed to type-check downstream: invalid `todo!(...)` in parameter lists (#36), the missing `WorldUserCommandHandler` bound on `handle_commands` (#37), `Box<&dyn _>` wrappers (#27), and so on. Each surfaced through a downstream consumer instead of in this crate's tests.

Running the templates through `cargo check` against a realistic user-side surface lets CI catch those before they ship.

## Notes

- The fixture crate lives under `target/sillyecs-compile-fixtures/<name>/`. A shared `CARGO_TARGET_DIR` (`target/sillyecs-compile-fixtures-target/`) keeps the incremental cache hot across runs. Cold first run ~13s; cached subsequent ~1s on my machine.
- Adding a new fixture: drop another `tests/fixtures/<name>/{ecs.yaml,user.rs}` pair and one `#[test]` calling `run_fixture("name")`. No harness changes needed.
- Fixture crate uses `edition = \"2021\"` to mirror the real downstream consumer (`.retro`). The workspace itself is on 2024, so a follow-up to exercise generated code under 2024 (which surfaces additional `unsafe_op_in_unsafe_fn` issues) is a separate piece of work.

## Test plan

- [x] `cargo test -p sillyecs-build` (all 7 existing tests still pass; new `full_coverage_fixture_compiles` passes)
- [x] Verified the new test fails loudly when the rendered code is broken (induced during development before the fixture was wired up correctly)