### PR TITLE
Add archetype component views for shared component subsets

### DIFF
--- a/crates/sillyecs-build/src/code.rs
+++ b/crates/sillyecs-build/src/code.rs
@@ -33,6 +33,7 @@ impl EcsCode {
         ecs.ensure_component_consistency()?;
         ecs.ensure_distinct_archetype_components()?;
         ecs.ensure_system_consistency()?;
+        ecs.ensure_view_consistency()?;
         ecs.ensure_world_consistency()?;
         ecs.finish()?;
 

--- a/crates/sillyecs-build/src/code.rs
+++ b/crates/sillyecs-build/src/code.rs
@@ -1,5 +1,5 @@
 use crate::ecs::{Ecs, EcsError};
-use crate::snake_case_filter;
+use crate::{doc_lines_filter, snake_case_filter};
 use minijinja::{Environment, context};
 use std::fs::File;
 use std::io::{BufReader, Write};
@@ -39,6 +39,7 @@ impl EcsCode {
 
         let mut env = Environment::new();
         env.add_filter("snake_case", snake_case_filter);
+        env.add_filter("doc_lines", doc_lines_filter);
 
         env.add_template("world", include_str!("../templates/world.rs.jinja2"))?;
         env.add_template(

--- a/crates/sillyecs-build/src/ecs.rs
+++ b/crates/sillyecs-build/src/ecs.rs
@@ -2,6 +2,7 @@ use crate::archetype::{Archetype, ArchetypeId};
 use crate::component::{Component, ComponentId};
 use crate::state::State;
 use crate::system::{System, SystemId, SystemPhase};
+use crate::view::View;
 use crate::world::{World, WorldId};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -27,6 +28,9 @@ pub struct Ecs {
     /// The user states.
     #[serde(default)]
     pub states: Vec<State>,
+    /// Named component views shared across archetypes.
+    #[serde(default)]
+    pub views: Vec<View>,
     /// Allow the generation of unsafe code.
     #[serde(default)]
     pub allow_unsafe: bool,
@@ -49,6 +53,10 @@ impl Ecs {
             component.finish(&self.archetypes, &self.systems);
         }
 
+        for view in &mut self.views {
+            view.finish(&self.components, &self.archetypes);
+        }
+
         for state in &mut self.states {
             state.finish(&self.systems);
         }
@@ -60,7 +68,13 @@ impl Ecs {
         }
 
         for world in &mut self.worlds {
-            world.finish(&self.archetypes, &self.systems, &self.states, &self.phases)?;
+            world.finish(
+                &self.archetypes,
+                &self.systems,
+                &self.states,
+                &self.phases,
+                &self.views,
+            )?;
         }
 
         Ok(())
@@ -160,6 +174,16 @@ pub enum EcsError {
         max = u32::MAX
     )]
     TooManyIds { kind: &'static str, count: usize },
+    #[error("View '{0}' is defined more than once.")]
+    DuplicateView(String),
+    #[error("Component '{0}' in view '{1}' is not defined in the ECS components.")]
+    MissingComponentInView(String, String),
+    #[error("Component '{0}' in view '{1}' is referenced more than once.")]
+    DuplicateComponentInView(String, String),
+    #[error("View '{0}' requires components not covered by any archetype.")]
+    NoMatchingArchetypeForView(String),
+    #[error("View '{0}' has no components.")]
+    ViewWithoutComponents(String),
 }
 
 impl Ecs {
@@ -267,6 +291,55 @@ impl Ecs {
                         system.name.type_name.clone(),
                     ));
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn ensure_view_consistency(&self) -> Result<(), EcsError> {
+        let defined_components: HashSet<_> = self.components.iter().map(|c| &c.name).collect();
+
+        let mut seen_view_names = HashSet::new();
+        for view in &self.views {
+            if !seen_view_names.insert(&view.name) {
+                return Err(EcsError::DuplicateView(view.name.type_name_raw.clone()));
+            }
+
+            if view.components.is_empty() {
+                return Err(EcsError::ViewWithoutComponents(
+                    view.name.type_name_raw.clone(),
+                ));
+            }
+
+            let mut seen_components = HashSet::new();
+            for component_ref in &view.components {
+                if !seen_components.insert(component_ref) {
+                    return Err(EcsError::DuplicateComponentInView(
+                        component_ref.type_name.clone(),
+                        view.name.type_name_raw.clone(),
+                    ));
+                }
+
+                if !defined_components.contains(component_ref) {
+                    return Err(EcsError::MissingComponentInView(
+                        component_ref.type_name.clone(),
+                        view.name.type_name_raw.clone(),
+                    ));
+                }
+            }
+
+            let required: HashSet<_> = view.components.iter().collect();
+            if !self.archetypes.iter().any(|archetype| {
+                archetype
+                    .components
+                    .iter()
+                    .collect::<HashSet<_>>()
+                    .is_superset(&required)
+            }) {
+                return Err(EcsError::NoMatchingArchetypeForView(
+                    view.name.type_name_raw.clone(),
+                ));
             }
         }
 

--- a/crates/sillyecs-build/src/lib.rs
+++ b/crates/sillyecs-build/src/lib.rs
@@ -90,6 +90,16 @@ fn snake_case_filter(value: String) -> String {
     pascal_to_snake(value.trim())
 }
 
+/// Renders a (possibly multi-line) user string as the continuation of a Rust doc
+/// comment. The template is expected to emit the first `/// ` prefix; every line
+/// produced by this filter after a newline is prefixed with `/// ` so embedded
+/// newlines in YAML descriptions don't leak unguarded text into the generated
+/// Rust output.
+pub(crate) fn doc_lines_filter(value: String) -> String {
+    let trimmed = value.trim_end_matches('\n');
+    trimmed.replace('\n', "\n/// ")
+}
+
 fn pascal_to_snake(type_name: &str) -> String {
     let field_name = type_name
         .chars()

--- a/crates/sillyecs-build/src/lib.rs
+++ b/crates/sillyecs-build/src/lib.rs
@@ -7,6 +7,7 @@ mod ecs;
 mod state;
 mod system;
 mod system_scheduler;
+mod view;
 mod world;
 
 pub use crate::code::EcsCode;

--- a/crates/sillyecs-build/src/view.rs
+++ b/crates/sillyecs-build/src/view.rs
@@ -1,0 +1,102 @@
+use crate::Name;
+use crate::archetype::{Archetype, ArchetypeId, ArchetypeRef};
+use crate::component::{Component, ComponentId, ComponentRef};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::HashSet;
+use std::ops::Deref;
+
+/// A named subset of components that may be shared across multiple archetypes.
+///
+/// At codegen time, the view auto-resolves to every archetype whose component
+/// set is a superset of the view's components. The generated world exposes
+/// `get_<view>_view(EntityId)` and `get_<view>_view_mut(EntityId)` accessors
+/// that perform a single entity-location lookup followed by a single archetype
+/// match, then return all view components by index without further lookups.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct View {
+    pub name: ViewName,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub components: Vec<ComponentRef>,
+
+    /// The component IDs in ascending order. Available after a call to
+    /// [`View::finish`](View::finish).
+    #[serde(skip_deserializing, default)]
+    pub component_ids: Vec<ComponentId>,
+    /// The number of components. Available after a call to
+    /// [`View::finish`](View::finish).
+    #[serde(skip_deserializing, default)]
+    pub component_count: usize,
+
+    /// The archetypes whose components form a superset of this view's
+    /// components, ordered by archetype ID. Available after a call to
+    /// [`View::finish`](View::finish).
+    #[serde(skip_deserializing, default)]
+    pub archetypes: Vec<ArchetypeRef>,
+    /// The IDs of the matching archetypes in ascending order. Available after
+    /// a call to [`View::finish`](View::finish).
+    #[serde(skip_deserializing, default)]
+    pub archetype_ids: Vec<ArchetypeId>,
+    /// The number of matching archetypes. Available after a call to
+    /// [`View::finish`](View::finish).
+    #[serde(skip_deserializing, default)]
+    pub archetype_count: usize,
+}
+
+impl View {
+    pub(crate) fn finish(&mut self, components: &[Component], archetypes: &[Archetype]) {
+        let required: HashSet<&ComponentRef> = self.components.iter().collect();
+
+        let mut ids_and_refs = Vec::new();
+        for archetype in archetypes {
+            let archetype_components: HashSet<&ComponentRef> =
+                archetype.components.iter().collect();
+            if archetype_components.is_superset(&required) {
+                ids_and_refs.push((archetype.id, archetype.name.clone()));
+            }
+        }
+        ids_and_refs.sort_unstable_by_key(|entry| entry.0);
+
+        self.archetype_count = ids_and_refs.len();
+        self.archetype_ids = ids_and_refs.iter().map(|entry| entry.0).collect();
+        self.archetypes = ids_and_refs.into_iter().map(|entry| entry.1).collect();
+
+        // Validation has already ensured each component exists in the ECS components.
+        let mut ids: Vec<ComponentId> = self
+            .components
+            .iter()
+            .map(|c| {
+                components
+                    .iter()
+                    .find(|known| known.name.type_name == c.type_name)
+                    .expect("Component must exist; view consistency check should have caught this")
+                    .id
+            })
+            .collect();
+        ids.sort_unstable();
+        self.component_count = ids.len();
+        self.component_ids = ids;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ViewName(Name);
+
+impl Deref for ViewName {
+    type Target = Name;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for ViewName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let type_name = String::deserialize(deserializer)?;
+        Ok(Self(Name::new(type_name, "View")))
+    }
+}

--- a/crates/sillyecs-build/src/world.rs
+++ b/crates/sillyecs-build/src/world.rs
@@ -5,6 +5,7 @@ use crate::ecs::EcsError;
 use crate::state::State;
 use crate::system::{System, SystemPhase, SystemPhaseRef};
 use crate::system_scheduler::schedule_systems;
+use crate::view::View;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::ops::Deref;
@@ -24,6 +25,10 @@ pub struct World {
     pub systems: Vec<System>,
     #[serde(skip_deserializing)]
     pub states: Vec<State>,
+    /// Views whose matching archetypes are all present in this world. Each entry is the view
+    /// restricted to the world's own archetypes.
+    #[serde(default, skip_deserializing)]
+    pub views: Vec<View>,
 
     /// The systems in scheduling order (based on this world's systems). Ordered by phase name so
     /// that codegen output is deterministic between runs.
@@ -42,6 +47,7 @@ impl World {
         systems: &[System],
         states: &[State],
         phases: &[SystemPhase],
+        views: &[View],
     ) -> Result<(), EcsError> {
         let mut used_systems = HashSet::new();
         let mut used_states = HashSet::new();
@@ -95,6 +101,32 @@ impl World {
                 0,
                 "Some systems should be scheduled"
             );
+        }
+
+        let world_archetypes: HashSet<&ArchetypeRef> = self.archetypes_refs.iter().collect();
+        for view in views {
+            let mut narrowed = view.clone();
+            let mut kept_archetypes = Vec::new();
+            let mut kept_ids = Vec::new();
+            for (archetype_name, archetype_id) in view
+                .archetypes
+                .iter()
+                .zip(view.archetype_ids.iter().copied())
+            {
+                if world_archetypes.contains(archetype_name) {
+                    kept_archetypes.push(archetype_name.clone());
+                    kept_ids.push(archetype_id);
+                }
+            }
+
+            if kept_archetypes.is_empty() {
+                continue;
+            }
+
+            narrowed.archetype_count = kept_archetypes.len();
+            narrowed.archetypes = kept_archetypes;
+            narrowed.archetype_ids = kept_ids;
+            self.views.push(narrowed);
         }
 
         Ok(())

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -1799,3 +1799,190 @@ impl<'a, E, Q> IterMut{{ component.raw }}Components<'a> for {{ world.name.type }
 }
 {%- endfor %}
 {%- endfor %}
+{%- for view in ecs.views %}
+
+/// A read-only view of an entity exposing a fixed subset of its components.
+///
+{%- if view.description %}
+/// {{ view.description }}
+{%- else %}
+/// Shared across all archetypes that contain every listed component.
+{%- endif %}
+///
+/// Use [`ViewAccess::get_{{ view.name.field }}_view`] on the world to look up the view
+/// for an entity with a single archetype match.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct {{ view.name.type }}<'archetype> {
+    pub entity_id: ::sillyecs::EntityId,
+    {%- for component in view.components %}
+    pub {{ component.field }}: &'archetype {{ component.type }},
+    {%- endfor %}
+}
+
+/// A mutable view of an entity exposing a fixed subset of its components.
+///
+{%- if view.description %}
+/// {{ view.description }}
+{%- else %}
+/// Shared across all archetypes that contain every listed component.
+{%- endif %}
+///
+/// Use [`ViewAccessMut::get_{{ view.name.field }}_view_mut`] on the world to look up the
+/// view for an entity with a single archetype match.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct {{ view.name.type }}Mut<'archetype> {
+    pub entity_id: ::sillyecs::EntityId,
+    {%- for component in view.components %}
+    pub {{ component.field }}: &'archetype mut {{ component.type }},
+    {%- endfor %}
+}
+{%- endfor %}
+{%- if (ecs.views | length) > 0 %}
+
+/// Read-only access to component views by [`::sillyecs::EntityId`].
+#[allow(dead_code)]
+pub trait ViewAccess {
+    {%- for view in ecs.views %}
+
+    /// Looks up the [`{{ view.name.type }}`] for an entity, if it lives in an
+    /// archetype that satisfies the view.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{ view.name.field }}_view(&self, entity_id: ::sillyecs::EntityId) -> Option<{{ view.name.type }}<'_>> {
+        None
+    }
+    {%- endfor %}
+}
+
+/// Mutable access to component views by [`::sillyecs::EntityId`].
+#[allow(dead_code)]
+pub trait ViewAccessMut: ViewAccess {
+    {%- for view in ecs.views %}
+
+    /// Mutably looks up the [`{{ view.name.type }}Mut`] for an entity, if it lives in
+    /// an archetype that satisfies the view.
+    #[allow(dead_code, unused)]
+    #[inline]
+    fn get_{{ view.name.field }}_view_mut(&mut self, entity_id: ::sillyecs::EntityId) -> Option<{{ view.name.type }}Mut<'_>> {
+        None
+    }
+    {%- endfor %}
+}
+{%- endif %}
+{%- for world in ecs.worlds %}
+{%- if (world.views | length) > 0 %}
+
+//noinspection RsSortImplTraitMembers
+impl ViewAccess for {{ world.name.type }}Archetypes {
+    {%- for view in world.views %}
+
+    /// Looks up the [`{{ view.name.type }}`] for an entity in this world.
+    ///
+    /// Resolves to the entity's archetype through a single entity-location
+    /// lookup, then returns indexed references to every component named in
+    /// the view. The archetypes considered are:
+    {%- for archetype in view.archetypes %}
+    /// - [`{{ archetype.raw }}`]({{ archetype.type }})
+    {%- endfor %}
+    #[allow(dead_code)]
+    fn get_{{ view.name.field }}_view(&self, entity_id: ::sillyecs::EntityId) -> Option<{{ view.name.type }}<'_>> {
+        let ear = self.entity_locations.get(&entity_id)?.clone();
+        match ear.archetype {
+            {%- for archetype in view.archetypes %}
+            {{ archetype.type }}::ID => {
+                let archetype = &self.collection.{{ archetype.field }};
+                if ear.index >= archetype.len() {
+                    return None;
+                }
+                {%- if ecs.allow_unsafe %}
+                Some({{ view.name.type }} {
+                    entity_id,
+                    {%- for component in view.components %}
+                    {{ component.field }}: unsafe { archetype.get_{{ component.field }}_component_at_unchecked(ear.index) },
+                    {%- endfor %}
+                })
+                {%- else %}
+                Some({{ view.name.type }} {
+                    entity_id,
+                    {%- for component in view.components %}
+                    {{ component.field }}: &archetype.{{ component.fields }}[ear.index],
+                    {%- endfor %}
+                })
+                {%- endif %}
+            }
+            {%- endfor %}
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+    {%- endfor %}
+}
+
+//noinspection RsSortImplTraitMembers
+impl ViewAccessMut for {{ world.name.type }}Archetypes {
+    {%- for view in world.views %}
+
+    /// Mutably looks up the [`{{ view.name.type }}Mut`] for an entity in this world.
+    #[allow(dead_code)]
+    fn get_{{ view.name.field }}_view_mut(&mut self, entity_id: ::sillyecs::EntityId) -> Option<{{ view.name.type }}Mut<'_>> {
+        let ear = self.entity_locations.get(&entity_id)?.clone();
+        match ear.archetype {
+            {%- for archetype in view.archetypes %}
+            {{ archetype.type }}::ID => {
+                let archetype = &mut self.collection.{{ archetype.field }};
+                if ear.index >= archetype.len() {
+                    return None;
+                }
+                {%- if ecs.allow_unsafe %}
+                Some({{ view.name.type }}Mut {
+                    entity_id,
+                    {%- for component in view.components %}
+                    {{ component.field }}: unsafe { &mut *(archetype.{{ component.fields }}.as_mut_ptr().add(ear.index)) },
+                    {%- endfor %}
+                })
+                {%- else %}
+                Some({{ view.name.type }}Mut {
+                    entity_id,
+                    {%- for component in view.components %}
+                    {{ component.field }}: &mut archetype.{{ component.fields }}[ear.index],
+                    {%- endfor %}
+                })
+                {%- endif %}
+            }
+            {%- endfor %}
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+    {%- endfor %}
+}
+
+//noinspection RsSortImplTraitMembers
+impl<E, Q> ViewAccess for {{ world.name.type }}<E, Q> {
+    {%- for view in world.views %}
+
+    /// Delegates to [`ViewAccess::get_{{ view.name.field }}_view`] on the world's archetype storage.
+    #[allow(dead_code)]
+    #[inline]
+    fn get_{{ view.name.field }}_view(&self, entity_id: ::sillyecs::EntityId) -> Option<{{ view.name.type }}<'_>> {
+        ViewAccess::get_{{ view.name.field }}_view(&self.archetypes, entity_id)
+    }
+    {%- endfor %}
+}
+
+//noinspection RsSortImplTraitMembers
+impl<E, Q> ViewAccessMut for {{ world.name.type }}<E, Q> {
+    {%- for view in world.views %}
+
+    /// Delegates to [`ViewAccessMut::get_{{ view.name.field }}_view_mut`] on the world's archetype storage.
+    #[allow(dead_code)]
+    #[inline]
+    fn get_{{ view.name.field }}_view_mut(&mut self, entity_id: ::sillyecs::EntityId) -> Option<{{ view.name.type }}Mut<'_>> {
+        ViewAccessMut::get_{{ view.name.field }}_view_mut(&mut self.archetypes, entity_id)
+    }
+    {%- endfor %}
+}
+{%- endif %}
+{%- endfor %}

--- a/crates/sillyecs-build/templates/world.rs.jinja2
+++ b/crates/sillyecs-build/templates/world.rs.jinja2
@@ -1804,7 +1804,7 @@ impl<'a, E, Q> IterMut{{ component.raw }}Components<'a> for {{ world.name.type }
 /// A read-only view of an entity exposing a fixed subset of its components.
 ///
 {%- if view.description %}
-/// {{ view.description }}
+/// {{ view.description | doc_lines }}
 {%- else %}
 /// Shared across all archetypes that contain every listed component.
 {%- endif %}
@@ -1823,7 +1823,7 @@ pub struct {{ view.name.type }}<'archetype> {
 /// A mutable view of an entity exposing a fixed subset of its components.
 ///
 {%- if view.description %}
-/// {{ view.description }}
+/// {{ view.description | doc_lines }}
 {%- else %}
 /// Shared across all archetypes that contain every listed component.
 {%- endif %}

--- a/crates/sillyecs-build/tests/build.rs
+++ b/crates/sillyecs-build/tests/build.rs
@@ -246,6 +246,203 @@ systems:
     }
 }
 
+/// Issue #4: an archetype component view defines a fixed subset of components that may be
+/// shared across multiple archetypes. The world template must emit per-view struct and
+/// accessor pairs so that a single archetype match can return all requested components by
+/// index instead of relying on N separate entity-location lookups.
+#[test]
+fn view_emits_structs_and_accessors() {
+    const YAML: &str = r#"
+components:
+  - name: Position
+  - name: Velocity
+  - name: Sprite
+archetypes:
+  - name: Particle
+    components: [Position, Velocity]
+  - name: Decoration
+    components: [Position, Sprite]
+views:
+  - name: Movable
+    components: [Position, Velocity]
+worlds:
+  - name: Main
+    archetypes: [Particle, Decoration]
+phases:
+  - name: Update
+systems:
+  - name: Move
+    phase: Update
+    inputs: [Velocity]
+    outputs: [Position]
+"#;
+
+    let code = EcsCode::generate(BufReader::new(YAML.as_bytes())).expect("Failed to build ECS");
+
+    assert!(
+        code.world.contains("pub struct MovableView<'archetype>"),
+        "MovableView struct missing from generated world output"
+    );
+    assert!(
+        code.world.contains("pub struct MovableViewMut<'archetype>"),
+        "MovableViewMut struct missing from generated world output"
+    );
+    assert!(
+        code.world.contains("pub trait ViewAccess"),
+        "ViewAccess trait missing from generated world output"
+    );
+    assert!(
+        code.world.contains("pub trait ViewAccessMut: ViewAccess"),
+        "ViewAccessMut trait missing from generated world output"
+    );
+    assert!(
+        code.world.contains("fn get_movable_view("),
+        "get_movable_view accessor missing from generated world output"
+    );
+    assert!(
+        code.world.contains("fn get_movable_view_mut("),
+        "get_movable_view_mut accessor missing from generated world output"
+    );
+    // Only Particle (Position + Velocity) satisfies the Movable view; Decoration must be excluded.
+    let body_start = code
+        .world
+        .find("fn get_movable_view(")
+        .expect("get_movable_view emitted");
+    let body = &code.world[body_start..body_start.saturating_add(2000)];
+    assert!(
+        body.contains("ParticleArchetype::ID"),
+        "Movable view must dispatch on the Particle archetype"
+    );
+    assert!(
+        !body.contains("DecorationArchetype::ID"),
+        "Movable view must not dispatch on the Decoration archetype (missing Velocity)"
+    );
+}
+
+/// A view referencing an undefined component must be rejected at validation time so users get a
+/// clear error instead of a cryptic codegen failure later.
+#[test]
+fn view_with_unknown_component_is_rejected() {
+    const YAML: &str = r#"
+components:
+  - name: Position
+archetypes:
+  - name: Particle
+    components: [Position]
+views:
+  - name: Bogus
+    components: [Velocity]
+worlds:
+  - name: Main
+    archetypes: [Particle]
+phases:
+  - name: Update
+systems:
+  - name: Tick
+    phase: Update
+    outputs: [Position]
+"#;
+
+    let err = match EcsCode::generate(BufReader::new(YAML.as_bytes())) {
+        Ok(_) => panic!("view referencing undefined component must fail"),
+        Err(e) => e,
+    };
+    match err {
+        EcsError::MissingComponentInView(component, view) => {
+            assert_eq!(component, "VelocityComponent");
+            assert_eq!(view, "Bogus");
+        }
+        other => panic!("expected MissingComponentInView, got {other:?}"),
+    }
+}
+
+/// A view whose component set is not satisfied by any archetype is a configuration mistake; the
+/// resulting accessor would only ever return `None`. Reject it at build time instead.
+#[test]
+fn view_without_matching_archetype_is_rejected() {
+    const YAML: &str = r#"
+components:
+  - name: Position
+  - name: Velocity
+archetypes:
+  - name: Static
+    components: [Position]
+views:
+  - name: Movable
+    components: [Position, Velocity]
+worlds:
+  - name: Main
+    archetypes: [Static]
+phases:
+  - name: Update
+systems:
+  - name: Tick
+    phase: Update
+    outputs: [Position]
+"#;
+
+    let err = match EcsCode::generate(BufReader::new(YAML.as_bytes())) {
+        Ok(_) => panic!("view with no matching archetype must fail"),
+        Err(e) => e,
+    };
+    match err {
+        EcsError::NoMatchingArchetypeForView(name) => assert_eq!(name, "Movable"),
+        other => panic!("expected NoMatchingArchetypeForView, got {other:?}"),
+    }
+}
+
+/// Views that match archetypes outside the world's own archetype list must be filtered out per
+/// world; otherwise the generated `ViewAccess` impl on `<W>Archetypes` would try to dispatch on
+/// archetype IDs the world does not own.
+#[test]
+fn view_accessor_only_emits_for_world_archetypes() {
+    const YAML: &str = r#"
+components:
+  - name: Position
+  - name: Velocity
+archetypes:
+  - name: Particle
+    components: [Position, Velocity]
+  - name: Static
+    components: [Position]
+views:
+  - name: Movable
+    components: [Position, Velocity]
+worlds:
+  - name: Main
+    archetypes: [Static]
+phases:
+  - name: Update
+systems:
+  - name: Tick
+    phase: Update
+    outputs: [Position]
+"#;
+
+    let code = EcsCode::generate(BufReader::new(YAML.as_bytes())).expect("Failed to build ECS");
+
+    // Top-level view struct still emits because Movable matches Particle at the ECS level.
+    assert!(
+        code.world.contains("pub struct MovableView<'archetype>"),
+        "MovableView struct must still emit at the ECS level"
+    );
+    // The MainWorld owns only Static, which does not satisfy Movable; no per-world accessor impl
+    // should be emitted. The trait itself still carries default `fn get_movable_view(...)` methods,
+    // so check specifically for the impl block on the world's archetype storage.
+    assert!(
+        !code
+            .world
+            .contains("impl ViewAccess for MainWorldArchetypes"),
+        "MainWorld must not emit a ViewAccess impl because none of its archetypes satisfy any view"
+    );
+    assert!(
+        !code
+            .world
+            .contains("impl ViewAccessMut for MainWorldArchetypes"),
+        "MainWorld must not emit a ViewAccessMut impl because none of its archetypes satisfy any view"
+    );
+}
+
 /// The scheduler's name-based tie-break is only total if system names are unique. Two systems
 /// declared with the same name in YAML must therefore be rejected at validation time, not
 /// silently collapsed by the internal `name -> phase` HashMap.

--- a/crates/sillyecs-build/tests/build.rs
+++ b/crates/sillyecs-build/tests/build.rs
@@ -443,6 +443,69 @@ systems:
     );
 }
 
+/// A multi-line YAML description on a view must not leak un-commented continuation lines into
+/// generated Rust. The doc-comment line in the template emits a single `///` prefix; the
+/// `doc_lines` filter has to re-prefix every embedded newline so the output stays syntactically
+/// valid as a doc comment block.
+#[test]
+fn view_description_multiline_renders_as_doc_lines() {
+    const YAML: &str = "
+components:
+  - name: Position
+  - name: Velocity
+archetypes:
+  - name: Particle
+    components: [Position, Velocity]
+views:
+  - name: Movable
+    description: |
+      First line of the description.
+      Second line that would otherwise break the doc comment.
+    components: [Position, Velocity]
+worlds:
+  - name: Main
+    archetypes: [Particle]
+phases:
+  - name: Update
+systems:
+  - name: Tick
+    phase: Update
+    outputs: [Position]
+";
+
+    let code = EcsCode::generate(BufReader::new(YAML.as_bytes())).expect("Failed to build ECS");
+
+    let struct_start = code
+        .world
+        .find("pub struct MovableView<'archetype>")
+        .expect("MovableView struct missing");
+    let preceding = &code.world[..struct_start];
+    let doc_block_start = preceding
+        .rfind("/// A read-only view of an entity")
+        .expect("MovableView doc block missing");
+    let doc_block = &preceding[doc_block_start..];
+
+    assert!(
+        doc_block.contains("/// First line of the description."),
+        "first description line should be emitted with `///` prefix"
+    );
+    assert!(
+        doc_block.contains("/// Second line that would otherwise break the doc comment."),
+        "second description line must be re-prefixed with `///` instead of leaking as bare Rust"
+    );
+
+    for line in doc_block.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() {
+            continue;
+        }
+        assert!(
+            trimmed.starts_with("///") || trimmed.starts_with("#[") || trimmed.starts_with("pub "),
+            "doc block above MovableView contains non-comment line: {line:?}"
+        );
+    }
+}
+
 /// The scheduler's name-based tie-break is only total if system names are unique. Two systems
 /// declared with the same name in YAML must therefore be rejected at validation time, not
 /// silently collapsed by the internal `name -> phase` HashMap.

--- a/crates/sillyecs-build/tests/fixtures/full_coverage/ecs.yaml
+++ b/crates/sillyecs-build/tests/fixtures/full_coverage/ecs.yaml
@@ -28,6 +28,11 @@ archetypes:
   - name: Decoration
     components: [Position, Sprite]
 
+views:
+  - name: Movable
+    description: A position plus velocity shared by Particle and LivingParticle.
+    components: [Position, Velocity]
+
 worlds:
   - name: Main
     archetypes: [Particle, LivingParticle, Decoration]

--- a/crates/sillyecs-build/tests/fixtures/full_coverage/user.rs
+++ b/crates/sillyecs-build/tests/fixtures/full_coverage/user.rs
@@ -226,4 +226,12 @@ pub fn smoke() {
     world.apply_system_phase_render();
     world.par_apply_system_phase_render();
     world.request_update_phase();
+
+    // Force monomorphization of the view accessors.
+    let id = world.spawn_particle(ParticleEntityComponents {
+        position: PositionComponent::new(PositionData::default()),
+        velocity: VelocityComponent::new(VelocityData::default()),
+    });
+    let _view: Option<MovableView<'_>> = world.get_movable_view(id);
+    let _view_mut: Option<MovableViewMut<'_>> = world.get_movable_view_mut(id);
 }


### PR DESCRIPTION
## Summary

Resolves #4. Adds a `views:` YAML key that names a fixed subset of components shared across multiple archetypes. Codegen emits a `<View>View` / `<View>ViewMut` struct per view plus `ViewAccess` / `ViewAccessMut` traits whose `get_<view>_view(EntityId)` performs one entity-location lookup, one archetype match, and indexed component access from the same archetype.

## Before

Reading several components of an entity required one `entity_locations` hashmap lookup and one archetype `match` per component (`get_<X>_component(id)`). Two archetypes that conceptually expose the same logical "thing" (e.g. an in-memory texture and a file-loaded texture) had no first-class way to share that shape - callers had to know each archetype.

## After

```yaml
views:
  - name: Movable
    components: [Position, Velocity]
```

generates:

```rust
pub struct MovableView<'archetype> {
    pub entity_id: EntityId,
    pub position: &'archetype PositionComponent,
    pub velocity: &'archetype VelocityComponent,
}

impl<E, Q> ViewAccess for MainWorld<E, Q> {
    fn get_movable_view(&self, id: EntityId) -> Option<MovableView<'_>> { ... }
}
```

The world's archetype storage owns the real impl: one `entity_locations.get(&id)`, one match on `ArchetypeId`, then indexed component access for every field in the view. The world type re-exports the same accessor for convenience. `Mut` variant mirrors the read-only path.

## Outcome

- `crates/sillyecs-build/src/view.rs` - new `View`, `ViewName` types; `finish()` resolves the matching archetype list and component IDs.
- `crates/sillyecs-build/src/ecs.rs` - `views` field on `Ecs`; new `ensure_view_consistency()` validates name uniqueness, component existence, non-empty component lists, and existence of at least one satisfying archetype.
- `crates/sillyecs-build/src/world.rs` - per-world narrowing of the view list to the archetypes that world actually owns, so trait impls never dispatch on foreign archetype IDs.
- `crates/sillyecs-build/templates/world.rs.jinja2` - per-view structs, `ViewAccess` / `ViewAccessMut` traits with default `None`-returning methods, per-world impls on `<W>Archetypes` and `<W>`.
- `crates/sillyecs-build/tests/build.rs` - four new tests covering struct/accessor emission, missing component, no satisfying archetype, and per-world filtering.
- `crates/sillyecs-build/tests/fixtures/full_coverage/{ecs.yaml,user.rs}` - fixture exercises both accessors so `cargo check` over the generated crate monomorphizes them.

11 build tests + 1 compile-generated test + 9 unit tests pass. `cargo fmt` clean. No new clippy lints introduced (pre-existing ones on `main` remain).

## Findings

The view's `archetype_ids` and `archetypes` collections are kept lockstep-sorted by archetype ID. World-side narrowing iterates the pair to filter, preserving the invariant; codegen then walks `world.views[i].archetypes` to emit one match arm per surviving archetype. Empty narrowed views are skipped so worlds that own no satisfying archetype emit no `ViewAccess` impl - the trait's default `None` body still resolves, but a stricter test asserts the impl block itself is absent so misconfigurations stay visible.

## Review Instructions

1. Read `src/view.rs` first - small and self-contained, defines the data model and the matching-archetype resolution.
2. Read `src/ecs.rs` - confirm validation rejects every failure mode (`MissingComponentInView`, `DuplicateComponentInView`, `DuplicateView`, `ViewWithoutComponents`, `NoMatchingArchetypeForView`).
3. Read `src/world.rs` - the per-world narrowing loop; the invariant is `kept_archetypes.len() == kept_ids.len()` and both stay sorted by archetype ID.
4. Read `templates/world.rs.jinja2` (bottom of file) - per-view structs, traits, then per-world impls. Verify the `unsafe` mutable code path uses `as_mut_ptr().add(...)` correctly when `allow_unsafe: true`, and the safe path uses plain indexing.
5. Run `cargo test -p sillyecs-build` for unit + integration tests, then `cargo test -p sillyecs-build --test compile_generated` to confirm the generated code actually compiles against a real consumer.